### PR TITLE
[ASAP-1676] - Fix production lambda timeouts

### DIFF
--- a/apps/auth0/src/post-login-add-metadata.ts
+++ b/apps/auth0/src/post-login-add-metadata.ts
@@ -141,7 +141,9 @@ const fetchUserMetadata = (
     headers: {
       Authorization: `Basic ${event.secrets.AUTH0_SHARED_SECRET}`,
     },
-    timeout: 10000,
+    // Auth0 actions are killed at 20s, so this can't go higher even though
+    // the auth0FetchByCode lambda now allows 29s.
+    timeout: 19000,
   }).json<Auth0UserResponse>();
 
 const getApiUrls = (

--- a/apps/crn-server/serverless/functions-api.ts
+++ b/apps/crn-server/serverless/functions-api.ts
@@ -66,6 +66,9 @@ export const apiFunctions: AWS['functions'] = {
     },
   },
   auth0FetchByCode: {
+    // Hits the 16s provider default on slow upstream calls, breaking login;
+    // 29 stays within API Gateway's 30s integration limit.
+    timeout: 29,
     handler: './src/handlers/webhooks/fetch-by-code/handler.handler',
     events: [
       {

--- a/apps/crn-server/serverless/functions-async.ts
+++ b/apps/crn-server/serverless/functions-async.ts
@@ -91,7 +91,9 @@ export const asyncFunctions: AWS['functions'] = {
     },
   },
   gcalEventsUpdatedContentfulProcess: {
-    timeout: 300,
+    // A full calendar resync (invalidated syncToken) takes ~5 minutes and
+    // times out at 300.
+    timeout: 600,
     handler:
       './src/handlers/webhooks/gcal-webhook-events-updated-process.handler',
     events: [

--- a/apps/crn-server/serverless/functions-async.ts
+++ b/apps/crn-server/serverless/functions-async.ts
@@ -42,6 +42,8 @@ export const asyncFunctions: AWS['functions'] = {
     environment: googleCalendarEnvironment,
   },
   syncActiveCampaignContact: {
+    // Hits the 16s provider default when ActiveCampaign responds slowly.
+    timeout: 120,
     handler: './src/handlers/user/sync-active-campaign-contact.handler',
     events: contentfulEventBridge(['UsersPublished']),
     environment: activeCampaignEnvironment,

--- a/apps/crn-server/serverless/functions-async.ts
+++ b/apps/crn-server/serverless/functions-async.ts
@@ -55,6 +55,9 @@ export const asyncFunctions: AWS['functions'] = {
     environment: activeCampaignEnvironment,
   },
   syncUserOrcidContentful: {
+    // Hits the 16s provider default on slow ORCID responses; matches
+    // cronjobSyncOrcidContentful.
+    timeout: 120,
     handler: './src/handlers/user/sync-orcid-handler.handler',
     events: contentfulEventBridge(['UsersPublished'], {
       maximumRetryAttempts: 2,

--- a/apps/crn-server/serverless/resources-api.ts
+++ b/apps/crn-server/serverless/resources-api.ts
@@ -552,7 +552,8 @@ export const apiResources = {
     Properties: {
       QueueName:
         '${self:service}-${self:provider.stage}-google-calendar-event-queue',
-      VisibilityTimeout: 300,
+      // Must be >= the gcalEventsUpdatedContentfulProcess lambda timeout (600).
+      VisibilityTimeout: 600,
       RedrivePolicy: {
         maxReceiveCount: 5,
         deadLetterTargetArn: {


### PR DESCRIPTION
[ASAP-1676](https://asaphub.atlassian.net/browse/ASAP-1676)

```
┌─────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────┐
│                    Sentry alert                     │                            Fix on this branch                             │
├─────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
│ production-auth0FetchByCode                         │ timeout: 29 (was the 16s default; 29 stays under API Gateway's 30s limit) │
├─────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
│ async-production-syncActiveCampaignContact          │ timeout: 120 (was 16s default)                                            │
├─────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
│ async-production-syncUserOrcidContentful            │ timeout: 120 (was 16s default, matches the orcid cronjob)                 │
├─────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
│ async-production-gcalEventsUpdatedContentfulProcess │ timeout: 300 → 600                                                        │
└─────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────┘
```

Follow-ups:
- `google-calendar-event-queue` SQS `VisibilityTimeout: 300 → 600` - Lambda rejects an event source mapping whose queue visibility timeout is below the function timeout (this is what failed the first deploy).
- Auth0 post-login action user-fetch `got` timeout `10s → 19s` so the login path can actually use the lambda's new headroom; capped at 19s because Auth0 kills actions at 20s.

[ASAP-1676]: https://asaphub.atlassian.net/browse/ASAP-1676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
