### PR TITLE
[ASAP-1673] - Redundant team name on reminders when user has multiple roles in same team

### DIFF
--- a/apps/crn-server/src/data-providers/contentful/reminder.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/reminder.data-provider.ts
@@ -1451,9 +1451,9 @@ export const getTeamNames = (
   teams: Maybe<string | undefined>[] | undefined,
 ): string => {
   if (teams) {
-    const teamNames = teams
-      .filter((teamName): teamName is string => teamName !== undefined)
-      .map((teamName) => `Team ${teamName}`);
+    const teamNames = [
+      ...new Set(teams.filter((teamName): teamName is string => !!teamName)),
+    ].map((teamName) => `Team ${teamName}`);
 
     if (teamNames.length === 1 && teamNames[0]) return teamNames[0];
     if (teamNames.length === 2) return teamNames.join(' and ');

--- a/apps/crn-server/test/data-providers/contentful/reminders/discussions.reminder.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/contentful/reminders/discussions.reminder.data-provider.test.ts
@@ -286,6 +286,54 @@ describe('Reminders data provider', () => {
         expect(result.items).toEqual([expectedReminder]);
       });
 
+      test('does not repeat a team when the open science member has multiple roles in it', async () => {
+        const discussionItem = getContentfulReminderDiscussionCollectionItem();
+        const user = getContentfulReminderUsersContent();
+        discussionItem!.message!.createdBy = {
+          ...discussionItem!.message!.createdBy,
+          openScienceTeamMember: true,
+          role: 'Staff',
+          sys: { id: 'user-who-started-discussion' },
+          teamsCollection: {
+            items: [
+              {
+                team: {
+                  sys: { id: 'team-1' },
+                  displayName: 'Alessi',
+                  inactiveSince: null,
+                },
+              },
+              {
+                team: {
+                  sys: { id: 'team-2' },
+                  displayName: 'Ant',
+                  inactiveSince: null,
+                },
+              },
+              {
+                team: {
+                  sys: { id: 'team-1' },
+                  displayName: 'Alessi',
+                  inactiveSince: null,
+                },
+              },
+            ],
+          },
+        };
+
+        const fetchRemindersOptions: FetchRemindersOptions = {
+          userId: 'first-author-user',
+          timezone,
+        };
+
+        mockContentfulGraphqlResponse(discussionItem, user);
+
+        const result = await remindersDataProvider.fetch(fetchRemindersOptions);
+        expect(
+          (result.items[0] as DiscussionCreatedReminder).data.userTeams,
+        ).toEqual('Team Alessi and Team Ant');
+      });
+
       test('returns reminder if user is os member assigned to manuscript and discussion was started by grantee', async () => {
         const discussionItem = getContentfulReminderDiscussionCollectionItem();
         const expectedReminder = getDiscussionStartedByGranteeReminder();
@@ -706,6 +754,17 @@ describe('Reminders data provider', () => {
 
     test('getTeamNames returns empty string when no teams provided', async () => {
       expect(getTeamNames(undefined)).toEqual('');
+    });
+
+    test('getTeamNames deduplicates teams repeated across roles', async () => {
+      expect(getTeamNames(['Alessi', 'Ant', 'Alessi'])).toEqual(
+        'Team Alessi and Team Ant',
+      );
+      expect(getTeamNames(['Alessi', 'Alessi'])).toEqual('Team Alessi');
+    });
+
+    test('getTeamNames ignores empty team names', async () => {
+      expect(getTeamNames([null, undefined, 'Ant'])).toEqual('Team Ant');
     });
   });
 });


### PR DESCRIPTION
[ASAP-1673](https://asaphub.atlassian.net/browse/ASAP-1673)

<img width="1899" height="257" alt="image" src="https://github.com/user-attachments/assets/9c903c90-6d23-46dd-8ba2-2cabb4e15554" />

[ASAP-1673]: https://asaphub.atlassian.net/browse/ASAP-1673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ