### PR TITLE
ASAP-1636 — Email validation on Contact Details

### DIFF
--- a/apps/crn-frontend/src/network/users/Editing.tsx
+++ b/apps/crn-frontend/src/network/users/Editing.tsx
@@ -2,11 +2,16 @@ import { Route, Routes, useNavigate } from 'react-router';
 import {
   PersonalInfoModal,
   ContactInfoModal,
+  contactInfoServerErrorPaths,
   ConfirmModal,
 } from '@asap-hub/react-components';
 import { UserResponse } from '@asap-hub/model';
 import { network } from '@asap-hub/routing';
-import { Frame, loadInstitutionOptions } from '@asap-hub/frontend-utils';
+import {
+  Frame,
+  loadInstitutionOptions,
+  toServerValidationError,
+} from '@asap-hub/frontend-utils';
 
 import { usePatchUserById } from './state';
 import { useManageUserAvatar } from './useManageUserAvatar';
@@ -58,7 +63,11 @@ const Editing: React.FC<EditingProps> = ({ user, backHref }) => {
               personalEmail={user.personalEmail}
               fallbackEmail={user.email}
               backHref={backHref}
-              onSave={patchUser}
+              onSave={(data) =>
+                patchUser(data).catch(
+                  toServerValidationError(contactInfoServerErrorPaths),
+                )
+              }
             />
           </Frame>
         }

--- a/apps/crn-frontend/src/network/users/__tests__/Editing.test.tsx
+++ b/apps/crn-frontend/src/network/users/__tests__/Editing.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createUserResponse } from '@asap-hub/fixtures';
+import { invalidEmailMessage } from '@asap-hub/react-components';
 import { network } from '@asap-hub/routing';
 import { User } from '@auth0/auth0-spa-js';
 import {
@@ -11,6 +12,7 @@ import {
   WhenReady,
 } from '@asap-hub/crn-frontend/src/auth/test-utils';
 import {
+  BackendError,
   createTestQueryClient,
   loadInstitutionOptions,
 } from '@asap-hub/frontend-utils';
@@ -447,6 +449,73 @@ describe('the contact info modal', () => {
       expect.objectContaining({ contactEmail: 'contact@example.comm' }),
       expect.any(String),
     );
+  });
+
+  // The modal cannot read a BackendError; this wiring is what turns the API's
+  // 400 into the field's inline error rather than the generic toast.
+  const rejectWith = (instancePath: string) => {
+    mockPatchUser.mockRejectedValueOnce(
+      new BackendError(
+        'failed',
+        {
+          error: 'Bad Request',
+          message: 'Validation error',
+          statusCode: 400,
+          data: [
+            {
+              instancePath,
+              keyword: 'pattern',
+              params: {},
+              schemaPath: `#/properties${instancePath}/pattern`,
+            },
+          ],
+        },
+        400,
+      ),
+    );
+  };
+
+  const renderContactInfo = () =>
+    renderWithRoot(
+      <MemoryRouter initialEntries={[`/profile${editContactInfo.template}`]}>
+        <Routes>
+          <Route
+            path="/profile/*"
+            element={
+              <Editing
+                user={{ ...createUserResponse(), id }}
+                backHref="/profile"
+              />
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+  it.each(['/contactEmail', '/personalEmail'])(
+    'reports an API rejection of %s on that field',
+    async (instancePath) => {
+      rejectWith(instancePath);
+      // setServerErrors lands outside act(); the assertion below is the proof.
+      const consoleMock = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const { findByText } = renderContactInfo();
+
+      await userEvent.click(await findByText(/save/i));
+
+      expect(await findByText(invalidEmailMessage)).toBeVisible();
+      consoleMock.mockRestore();
+    },
+  );
+
+  it('reports generically when the rejection names another field', async () => {
+    rejectWith('/jobTitle');
+    const { findByText } = renderContactInfo();
+
+    await userEvent.click(await findByText(/save/i));
+
+    expect(await findByText(/unable to save your changes/i)).toBeVisible();
   });
 });
 

--- a/apps/crn-frontend/src/network/users/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/network/users/__tests__/api.test.ts
@@ -17,7 +17,7 @@ import type {
 } from '@asap-hub/algolia';
 import { createAlgoliaResponse } from '@asap-hub/algolia';
 
-import { GetListOptions } from '@asap-hub/frontend-utils';
+import { BackendError, GetListOptions } from '@asap-hub/frontend-utils';
 
 import { API_BASE_URL } from '../../../config';
 import {
@@ -410,6 +410,41 @@ describe('patchUser', () => {
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"Failed to update user with id 42. Expected status 2xx. Received status 500."`,
     );
+  });
+
+  // The modal turns this body into the offending field's inline error, so
+  // discarding it would leave the user with only the generic toast.
+  it('preserves the validation body of a rejection', async () => {
+    const patch = { contactEmail: 'test@test' };
+    const body = {
+      error: 'Bad Request',
+      message: 'Validation error',
+      statusCode: 400,
+      data: [
+        {
+          instancePath: '/contactEmail',
+          keyword: 'pattern',
+          params: {},
+          schemaPath: '#/properties/contactEmail/pattern',
+        },
+      ],
+    };
+    nock(API_BASE_URL).patch('/users/42', patch).reply(400, body);
+
+    const error = await patchUser('42', patch, '').catch((thrown) => thrown);
+
+    expect(error).toBeInstanceOf(BackendError);
+    expect(error).toMatchObject({ statusCode: 400, response: body });
+  });
+
+  it('tolerates a rejection carrying no JSON body', async () => {
+    const patch = { biography: 'New Bio' };
+    nock(API_BASE_URL).patch('/users/42', patch).reply(502, '<html>502</html>');
+
+    const error = await patchUser('42', patch, '').catch((thrown) => thrown);
+
+    expect(error).toBeInstanceOf(BackendError);
+    expect(error).toMatchObject({ statusCode: 502, response: undefined });
   });
 });
 

--- a/apps/crn-frontend/src/network/users/api.ts
+++ b/apps/crn-frontend/src/network/users/api.ts
@@ -1,5 +1,9 @@
 import type { AlgoliaClient } from '@asap-hub/algolia';
-import { createSentryHeaders, GetListOptions } from '@asap-hub/frontend-utils';
+import {
+  BackendError,
+  createSentryHeaders,
+  GetListOptions,
+} from '@asap-hub/frontend-utils';
 import {
   ExternalAuthorResponse,
   ListResponse,
@@ -128,8 +132,12 @@ export const patchUser = async (
     body: JSON.stringify(patch),
   });
   if (!resp.ok) {
-    throw new Error(
+    // The body carries which field the API rejected, which the modal turns into
+    // that field's inline error. A plain Error would discard it.
+    throw new BackendError(
       `Failed to update user with id ${id}. Expected status 2xx. Received status ${`${resp.status} ${resp.statusText}`.trim()}.`,
+      await resp.json().catch(() => undefined),
+      resp.status,
     );
   }
   return resp.json();

--- a/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
+++ b/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
@@ -1,4 +1,4 @@
-import { Frame } from '@asap-hub/frontend-utils';
+import { Frame, toServerValidationError } from '@asap-hub/frontend-utils';
 import {
   researchOutputDocumentTypeToType,
   ResearchOutputResponse,
@@ -21,7 +21,6 @@ import React, { ReactNode, useCallback, useEffect, useState } from 'react';
 import { resolveResearchOutputFlowId } from '../../shared-research/util';
 import { useResearchOutputPermissions } from '../../shared-research/state';
 import {
-  toServerValidationError,
   paramOutputDocumentTypeToResearchOutputDocumentType,
   useAuthorSuggestions,
   useGeneratedContent,

--- a/apps/crn-frontend/src/projects/TeamBasedOutput.tsx
+++ b/apps/crn-frontend/src/projects/TeamBasedOutput.tsx
@@ -1,3 +1,4 @@
+import { toServerValidationError } from '@asap-hub/frontend-utils';
 import {
   ManuscriptVersionResponse,
   researchOutputDocumentTypeToType,
@@ -48,7 +49,6 @@ import {
   useRelatedResearchSuggestions,
   useResearchTags,
   useTeamSuggestions,
-  toServerValidationError,
 } from '../shared-state';
 import { useTeamById } from '../network/teams/state';
 

--- a/apps/crn-frontend/src/projects/UserBasedOutput.tsx
+++ b/apps/crn-frontend/src/projects/UserBasedOutput.tsx
@@ -1,3 +1,4 @@
+import { toServerValidationError } from '@asap-hub/frontend-utils';
 import {
   ManuscriptVersionResponse,
   researchOutputDocumentTypeToType,
@@ -43,7 +44,6 @@ import {
   useRelatedEventsSuggestions,
   useRelatedResearchSuggestions,
   useResearchTags,
-  toServerValidationError,
 } from '../shared-state';
 
 type UserBasedOutputProps = {

--- a/apps/crn-frontend/src/shared-state/shared-research.ts
+++ b/apps/crn-frontend/src/shared-state/shared-research.ts
@@ -1,11 +1,5 @@
 import { OutputDocumentTypeParameter } from '@asap-hub/routing';
 import {
-  BackendError,
-  validationErrorsAreSupported,
-} from '@asap-hub/frontend-utils';
-
-import {
-  isValidationErrorResponse,
   ResearchOutputDocumentType,
   ResearchOutputPostRequest,
   ResearchOutputPutRequest,
@@ -13,7 +7,6 @@ import {
   ResearchThemeResponse,
   ResearchThemeType,
   ResourceTypeResponse,
-  ServerValidationError,
 } from '@asap-hub/model';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useAuthorization } from '../auth/useAuthorization';
@@ -58,25 +51,6 @@ export function paramOutputDocumentTypeToResearchOutputDocumentType(
       return 'Article';
   }
 }
-
-/**
- * Translates a backend validation response into a `ServerValidationError` so the
- * form can surface it through the same path as its own field validation.
- */
-export const toServerValidationError =
-  (supportedErrors: string[]) =>
-  (error: unknown): never => {
-    if (error instanceof BackendError) {
-      const { response } = error;
-      if (
-        isValidationErrorResponse(response) &&
-        validationErrorsAreSupported(response, supportedErrors)
-      ) {
-        throw new ServerValidationError(response.data);
-      }
-    }
-    throw error;
-  };
 
 export const useRelatedResearchSuggestions = (currentId?: string) => {
   const algoliaClient = useAlgolia();

--- a/apps/crn-server/src/validation/user.validation.ts
+++ b/apps/crn-server/src/validation/user.validation.ts
@@ -1,6 +1,15 @@
 import { teamRole, userDegree, UserPatchRequest } from '@asap-hub/model';
 import { validateInput } from '@asap-hub/server-common';
+import { crnEmailExpression } from '@asap-hub/validation';
 import { JSONSchemaType } from 'ajv';
+
+// Defence in depth. The modal validates against the same expression, so a
+// request that reaches here with a bad address did not come from the form.
+const emailField = {
+  type: 'string',
+  nullable: true,
+  pattern: crnEmailExpression,
+} as const;
 
 const userPatchRequestValidationSchema: JSONSchemaType<UserPatchRequest> = {
   type: 'object',
@@ -8,8 +17,8 @@ const userPatchRequestValidationSchema: JSONSchemaType<UserPatchRequest> = {
     jobTitle: { type: 'string', nullable: true },
     onboarded: { type: 'boolean', nullable: true },
     dismissedGettingStarted: { type: 'boolean', nullable: true },
-    contactEmail: { type: 'string', nullable: true },
-    personalEmail: { type: 'string', nullable: true },
+    contactEmail: emailField,
+    personalEmail: emailField,
     firstName: { type: 'string', nullable: true },
     middleName: { type: 'string', nullable: true },
     lastName: { type: 'string', nullable: true },
@@ -74,6 +83,10 @@ export const validateUserPatchRequest = validateInput(
   userPatchRequestValidationSchema,
   {
     skipNull: true,
+    // Report every failure, not just the first: the Contact Details form marks
+    // both email fields at once, and with the default AJV setting a request
+    // failing both would come back naming only contactEmail.
+    allErrors: true,
   },
 );
 

--- a/apps/crn-server/test/routes/user.route.test.ts
+++ b/apps/crn-server/test/routes/user.route.test.ts
@@ -415,7 +415,6 @@ describe('/users/ route', () => {
       const stringFields: StringKeys<UserPatchRequest> = [
         'biography',
         'city',
-        'contactEmail',
         'country',
         'expertiseAndResourceDescription',
         'firstName',
@@ -446,6 +445,63 @@ describe('/users/ route', () => {
               .send({ [parameter]: null });
 
             expect(response.status).toBe(200);
+          });
+        },
+      );
+
+      test('Should report both email fields when both are invalid', async () => {
+        const response = await supertest(appWithMockedAuth)
+          .patch(`/users/${userId}`)
+          .send({ contactEmail: 'test@test', personalEmail: 'a@b' });
+
+        expect(response.status).toBe(400);
+        expect(
+          response.body.data.map(
+            ({ instancePath }: { instancePath: string }) => instancePath,
+          ),
+        ).toEqual(expect.arrayContaining(['/contactEmail', '/personalEmail']));
+      });
+
+      describe.each(['contactEmail', 'personalEmail'])(
+        'For the %s field',
+        (parameter) => {
+          test.each(['', null, 'name@gmail.com', "o'brien@x.com"])(
+            'Should accept %p',
+            async (value) => {
+              const response = await supertest(appWithMockedAuth)
+                .patch(`/users/${userId}`)
+                .send({ [parameter]: value });
+
+              expect(response.status).toBe(200);
+            },
+          );
+
+          test.each([
+            ['test@test', 'the content model requires a dot in the domain'],
+            ['a!b@c.com', 'the content model disallows ! in the local part'],
+            ['some random string', 'it is not an email at all'],
+            [`${'a'.repeat(250)}@gmail.com`, 'it exceeds the Symbol cap'],
+          ])('Should reject %p, because %s', async (value) => {
+            const response = await supertest(appWithMockedAuth)
+              .patch(`/users/${userId}`)
+              .send({ [parameter]: value });
+
+            expect(response.status).toBe(400);
+            expect(response.body.data).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({ instancePath: `/${parameter}` }),
+              ]),
+            );
+          });
+
+          test('Should not reach the controller when the value is rejected', async () => {
+            userControllerMock.update.mockClear();
+
+            await supertest(appWithMockedAuth)
+              .patch(`/users/${userId}`)
+              .send({ [parameter]: 'test@test' });
+
+            expect(userControllerMock.update).not.toHaveBeenCalled();
           });
         },
       );

--- a/apps/gp2-frontend/src/__tests__/outputs.test.ts
+++ b/apps/gp2-frontend/src/__tests__/outputs.test.ts
@@ -1,0 +1,61 @@
+import { BackendError } from '@asap-hub/frontend-utils';
+import { ValidationErrorResponse } from '@asap-hub/model';
+import { handleError } from '../outputs';
+
+describe('handleError', () => {
+  const setErrors = jest.fn();
+  const handle = handleError(['/link'], setErrors);
+
+  beforeEach(jest.resetAllMocks);
+
+  const backendError = (response: unknown) =>
+    new BackendError('failed', response as ValidationErrorResponse, 400);
+
+  const validationBody = (instancePath: string) => ({
+    error: 'Bad Request' as const,
+    message: 'Validation error' as const,
+    statusCode: 400,
+    data: [
+      {
+        instancePath,
+        keyword: 'pattern',
+        params: {},
+        schemaPath: `#/properties${instancePath}/pattern`,
+      },
+    ],
+  });
+
+  it('reports a supported validation error to the form', () => {
+    handle(backendError(validationBody('/link')));
+
+    expect(setErrors).toHaveBeenCalledWith(validationBody('/link').data);
+  });
+
+  it('rethrows when a path is not one the form can render', () => {
+    const error = backendError(validationBody('/description'));
+
+    expect(() => handle(error)).toThrow(error);
+    expect(setErrors).not.toHaveBeenCalled();
+  });
+
+  // A failure body is whatever the response parsed to. Reading `.message` or
+  // `.data.length` off these threw a TypeError from inside the caller's catch,
+  // masking the real API error.
+  it.each([
+    ['the body is absent', undefined],
+    ['the body is not an object', 'upstream exploded'],
+    ['the body is null', null],
+    ['the body has data but no message', { statusCode: 400, data: [] }],
+  ])('rethrows unchanged when %s', (_label, response) => {
+    const error = backendError(response);
+
+    expect(() => handle(error)).toThrow(error);
+    expect(setErrors).not.toHaveBeenCalled();
+  });
+
+  it('rethrows a non-BackendError unchanged', () => {
+    const error = new Error('boom');
+
+    expect(() => handle(error)).toThrow(error);
+  });
+});

--- a/apps/gp2-frontend/src/onboarding/CoreDetails.tsx
+++ b/apps/gp2-frontend/src/onboarding/CoreDetails.tsx
@@ -1,5 +1,6 @@
 import {
   ContactInformationModal,
+  contactInformationServerErrorPaths,
   KeyInformationModal,
   OnboardingCoreDetails,
 } from '@asap-hub/gp2-components';
@@ -7,7 +8,10 @@ import { NotFoundPage } from '@asap-hub/react-components';
 import { useCurrentUserGP2 } from '@asap-hub/react-context';
 import { gp2 } from '@asap-hub/routing';
 import { Route, Routes, useNavigate } from 'react-router';
-import { loadInstitutionOptions } from '@asap-hub/frontend-utils';
+import {
+  loadInstitutionOptions,
+  toServerValidationError,
+} from '@asap-hub/frontend-utils';
 import { useSelectAvatar } from '../hooks/useSelectAvatar';
 import countryCodesSuggestions from '../users/country-codes-suggestions';
 import locationSuggestions from '../users/location-suggestions';
@@ -59,7 +63,9 @@ const CoreDetails: React.FC<Record<string, never>> = () => {
                 countryCodeSuggestions={countryCodesSuggestions}
                 backHref={onboarding({}).coreDetails({}).$}
                 onSave={async (patchedUser) => {
-                  await patchUser(patchedUser);
+                  await patchUser(patchedUser).catch(
+                    toServerValidationError(contactInformationServerErrorPaths),
+                  );
                   void navigate(onboarding({}).coreDetails({}).$);
                 }}
               />

--- a/apps/gp2-frontend/src/onboarding/Preview.tsx
+++ b/apps/gp2-frontend/src/onboarding/Preview.tsx
@@ -1,6 +1,7 @@
 import {
   BiographyModal,
   ContactInformationModal,
+  contactInformationServerErrorPaths,
   ContributingCohortsModal,
   FundingProviderModal,
   KeyInformationModal,
@@ -14,7 +15,10 @@ import { NotFoundPage } from '@asap-hub/react-components';
 import { useCurrentUserGP2 } from '@asap-hub/react-context';
 import { gp2 as gp2Routing } from '@asap-hub/routing';
 import { Route, Routes } from 'react-router';
-import { loadInstitutionOptions } from '@asap-hub/frontend-utils';
+import {
+  loadInstitutionOptions,
+  toServerValidationError,
+} from '@asap-hub/frontend-utils';
 import { useSelectAvatar } from '../hooks/useSelectAvatar';
 import countryCodesSuggestions from '../users/country-codes-suggestions';
 import locationSuggestions from '../users/location-suggestions';
@@ -85,6 +89,15 @@ const Preview: React.FC<Record<string, never>> = () => {
               <ContactInformationModal
                 {...userData}
                 {...commonModalProps}
+                onSave={(patchedUser) =>
+                  commonModalProps
+                    .onSave(patchedUser)
+                    .catch(
+                      toServerValidationError(
+                        contactInformationServerErrorPaths,
+                      ),
+                    )
+                }
                 countryCodeSuggestions={countryCodesSuggestions}
               />
             }

--- a/apps/gp2-frontend/src/onboarding/__tests__/CoreDetails.test.tsx
+++ b/apps/gp2-frontend/src/onboarding/__tests__/CoreDetails.test.tsx
@@ -1,6 +1,7 @@
 import { Auth0, Auth0User, gp2 } from '@asap-hub/auth';
 import { mockConsoleError } from '@asap-hub/dom-test-utils';
 import { gp2 as gp2Fixtures } from '@asap-hub/fixtures';
+import { invalidEmailMessage } from '@asap-hub/react-components';
 import { ToastContext } from '@asap-hub/react-context';
 import { gp2 as gp2Routing } from '@asap-hub/routing';
 import { Auth0Client } from '@auth0/auth0-spa-js';
@@ -13,6 +14,7 @@ import { ContextType, Suspense } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { QueryClientProvider } from '@tanstack/react-query';
 import {
+  BackendError,
   createTestQueryClient,
   loadInstitutionOptions,
 } from '@asap-hub/frontend-utils';
@@ -210,6 +212,50 @@ describe('CoreDetails', () => {
       }),
       expect.anything(),
     );
+  });
+
+  // This mount was left unwired once already: without the converter a server
+  // rejection stays a raw BackendError and the user gets only the generic
+  // toast, with nothing marking the field.
+  it('shows an API email rejection on the field', async () => {
+    // setServerError lands outside act(); the assertions below are the proof.
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const user = gp2Fixtures.createUserResponse();
+    mockGetUser.mockResolvedValueOnce(user);
+    mockPatchUser.mockRejectedValueOnce(
+      new BackendError(
+        'failed',
+        {
+          error: 'Bad Request',
+          message: 'Validation error',
+          statusCode: 400,
+          data: [
+            {
+              instancePath: '/alternativeEmail',
+              keyword: 'pattern',
+              params: {},
+              schemaPath: '#/properties/alternativeEmail/pattern',
+            },
+          ],
+        },
+        400,
+      ),
+    );
+    await renderCoreDetails(user.id);
+
+    const [, contactInformationEditButton] = screen.getAllByRole('link', {
+      name: 'Edit Edit',
+    });
+    await userEvent.click(contactInformationEditButton!);
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText(invalidEmailMessage)).toBeVisible();
+    expect(
+      screen.queryByText(/unable to save your changes/i),
+    ).not.toBeInTheDocument();
+    consoleErrorSpy.mockRestore();
   });
 
   it('updates the avatar', async () => {

--- a/apps/gp2-frontend/src/outputs.ts
+++ b/apps/gp2-frontend/src/outputs.ts
@@ -1,11 +1,5 @@
-import {
-  BackendError,
-  validationErrorsAreSupported,
-} from '@asap-hub/frontend-utils';
-import {
-  isValidationErrorResponse,
-  ValidationErrorResponse,
-} from '@asap-hub/model';
+import { getSupportedValidationErrors } from '@asap-hub/frontend-utils';
+import { ValidationErrorResponse } from '@asap-hub/model';
 import { useAuthorization } from './auth/useAuthorization';
 import { getEvents } from './events/api';
 import { useAlgolia } from './hooks/algolia';
@@ -87,15 +81,11 @@ export const handleError =
     setErrors: (errors: ValidationErrorResponse['data']) => void,
   ) =>
   (error: unknown) => {
-    if (error instanceof BackendError) {
-      const { response } = error;
-      if (
-        isValidationErrorResponse(response) &&
-        validationErrorsAreSupported(response, supportedErrors)
-      ) {
-        setErrors(response.data);
-        return;
-      }
-    }
-    throw error;
+    const validationErrors = getSupportedValidationErrors(
+      error,
+      supportedErrors,
+    );
+    if (!validationErrors) throw error;
+
+    setErrors(validationErrors);
   };

--- a/apps/gp2-frontend/src/users/UserDetail.tsx
+++ b/apps/gp2-frontend/src/users/UserDetail.tsx
@@ -1,6 +1,7 @@
 import {
   BiographyModal,
   ContactInformationModal,
+  contactInformationServerErrorPaths,
   ContributingCohortsModal,
   FundingProviderModal,
   KeyInformationModal,
@@ -21,7 +22,10 @@ import {
   useLocation,
   useNavigate,
 } from 'react-router';
-import { loadInstitutionOptions } from '@asap-hub/frontend-utils';
+import {
+  loadInstitutionOptions,
+  toServerValidationError,
+} from '@asap-hub/frontend-utils';
 import EventsList from '../events/EventsList';
 import { useUpcomingAndPastEvents } from '../events/state';
 import Frame from '../Frame';
@@ -151,6 +155,15 @@ const UserDetail: FC<UserDetailProps> = ({ currentTime }) => {
                         <ContactInformationModal
                           {...user}
                           {...commonModalProps}
+                          onSave={(patchedUser) =>
+                            commonModalProps
+                              .onSave(patchedUser)
+                              .catch(
+                                toServerValidationError(
+                                  contactInformationServerErrorPaths,
+                                ),
+                              )
+                          }
                           countryCodeSuggestions={countryCodesSuggestions}
                         />
                       }

--- a/apps/gp2-frontend/src/users/__tests__/api.test.tsx
+++ b/apps/gp2-frontend/src/users/__tests__/api.test.tsx
@@ -1,7 +1,7 @@
 import { AlgoliaSearchClient, ClientSearchResponse } from '@asap-hub/algolia';
 import { disable, enable, reset } from '@asap-hub/flags';
 import { gp2 as gp2Fixtures } from '@asap-hub/fixtures';
-import { GetListOptions } from '@asap-hub/frontend-utils';
+import { BackendError, GetListOptions } from '@asap-hub/frontend-utils';
 import { gp2 as gp2Model } from '@asap-hub/model';
 import nock from 'nock';
 import { API_BASE_URL } from '../../config';
@@ -413,6 +413,41 @@ describe('patchUser', () => {
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"Failed to update user with id 42. Expected status 2xx. Received status 500."`,
     );
+  });
+
+  // The modal turns this body into the offending field's inline error, so
+  // discarding it would leave the user with only the generic toast.
+  it('preserves the validation body of a rejection', async () => {
+    const patch = { alternativeEmail: 'test@test' };
+    const body = {
+      error: 'Bad Request',
+      message: 'Validation error',
+      statusCode: 400,
+      data: [
+        {
+          instancePath: '/alternativeEmail',
+          keyword: 'pattern',
+          params: {},
+          schemaPath: '#/properties/alternativeEmail/pattern',
+        },
+      ],
+    };
+    nock(API_BASE_URL).patch('/users/42', patch).reply(400, body);
+
+    const error = await patchUser('42', patch, '').catch((thrown) => thrown);
+
+    expect(error).toBeInstanceOf(BackendError);
+    expect(error).toMatchObject({ statusCode: 400, response: body });
+  });
+
+  it('tolerates a rejection carrying no JSON body', async () => {
+    const patch = { firstName: 'New Name' };
+    nock(API_BASE_URL).patch('/users/42', patch).reply(502, '<html>502</html>');
+
+    const error = await patchUser('42', patch, '').catch((thrown) => thrown);
+
+    expect(error).toBeInstanceOf(BackendError);
+    expect(error).toMatchObject({ statusCode: 502, response: undefined });
   });
 });
 

--- a/apps/gp2-frontend/src/users/api.ts
+++ b/apps/gp2-frontend/src/users/api.ts
@@ -1,6 +1,10 @@
 import { AlgoliaClient } from '@asap-hub/algolia';
 import { isEnabled } from '@asap-hub/flags';
-import { createSentryHeaders, GetListOptions } from '@asap-hub/frontend-utils';
+import {
+  BackendError,
+  createSentryHeaders,
+  GetListOptions,
+} from '@asap-hub/frontend-utils';
 import { gp2 } from '@asap-hub/model';
 import { API_BASE_URL } from '../config';
 
@@ -154,8 +158,12 @@ export const patchUser = async (
     body: JSON.stringify(patch),
   });
   if (!resp.ok) {
-    throw new Error(
+    // The body names the field the API rejected, which the modal turns into
+    // that field's inline error. A plain Error would discard it.
+    throw new BackendError(
       `Failed to update user with id ${id}. Expected status 2xx. Received status ${`${resp.status} ${resp.statusText}`.trim()}.`,
+      await resp.json().catch(() => undefined),
+      resp.status,
     );
   }
   return resp.json();

--- a/apps/gp2-server/src/validation/user.validation.ts
+++ b/apps/gp2-server/src/validation/user.validation.ts
@@ -1,7 +1,7 @@
 import { gp2 } from '@asap-hub/model';
 import { validateInput } from '@asap-hub/server-common';
 import {
-  emailExpression,
+  gp2EmailExpression,
   orcidExpression,
   telephoneCountryExpression,
   telephoneNumberExpression,
@@ -69,10 +69,11 @@ const userPatchRequestValidationSchema: JSONSchemaType<gp2.UserPatchRequest> = {
       nullable: true,
     },
     onboarded: { type: 'boolean', nullable: true },
+    // Defence in depth behind the form, which validates against the same rule.
     alternativeEmail: {
       type: 'string',
       nullable: true,
-      pattern: emailExpression,
+      pattern: gp2EmailExpression,
     },
     telephone: {
       nullable: true,

--- a/apps/gp2-server/test/routes/user.route.test.ts
+++ b/apps/gp2-server/test/routes/user.route.test.ts
@@ -383,14 +383,27 @@ describe('/users/ route', () => {
           });
         expect(response.status).toBe(200);
       });
-      test('does not allow invalid secondary email', async () => {
+      test('allows a valid secondary email', async () => {
         const response = await supertest(app)
           .patch(`/users/${loggedInUserId}`)
-          .send({
-            alternativeEmail: 'invalid-email',
-          });
-        expect(response.status).toBe(400);
+          .send({ alternativeEmail: 'name@gmail.com' });
+
+        expect(response.status).toBe(200);
       });
+
+      // test@test and the apostrophe reached Contentful before and failed at the
+      // write with no field named: the GP2 content model requires a dot in the
+      // domain and disallows the apostrophe that CRN permits.
+      test.each(['invalid-email', 'test@test', "o'brien@x.com"])(
+        'does not allow %p as a secondary email',
+        async (alternativeEmail) => {
+          const response = await supertest(app)
+            .patch(`/users/${loggedInUserId}`)
+            .send({ alternativeEmail });
+
+          expect(response.status).toBe(400);
+        },
+      );
 
       describe('telephone', () => {
         test('allow valid inputs', async () => {

--- a/packages/frontend-utils/src/api-util/__test__/api-util.test.tsx
+++ b/packages/frontend-utils/src/api-util/__test__/api-util.test.tsx
@@ -1,10 +1,14 @@
-import { ValidationErrorResponse } from '@asap-hub/model';
+import {
+  ServerValidationError,
+  ValidationErrorResponse,
+} from '@asap-hub/model';
 import {
   BackendError,
   createListApiUrlFactory,
   createSentryHeaders,
   validationErrorsAreSupported,
   clearAjvErrorForPath,
+  toServerValidationError,
   getTimezone,
 } from '../api-util';
 
@@ -184,6 +188,95 @@ describe('validationErrorsAreSupported', () => {
         ['/2', '/3'],
       ),
     ).toBe(false);
+  });
+});
+
+describe('toServerValidationError', () => {
+  const convert = toServerValidationError(['/contactEmail']);
+
+  const backendError = (response: unknown) =>
+    new BackendError('failed', response as ValidationErrorResponse, 400);
+
+  const validationBody = (instancePath: string) => ({
+    error: 'Bad Request' as const,
+    message: 'Validation error' as const,
+    statusCode: 400,
+    data: [
+      {
+        instancePath,
+        keyword: 'pattern',
+        params: {},
+        schemaPath: `#/properties${instancePath}/pattern`,
+      },
+    ],
+  });
+
+  const capture = (error: unknown) => {
+    try {
+      convert(error);
+      return undefined;
+    } catch (thrown) {
+      return thrown;
+    }
+  };
+
+  it('converts a supported validation response', () => {
+    const thrown = capture(backendError(validationBody('/contactEmail')));
+
+    expect(thrown).toBeInstanceOf(ServerValidationError);
+    expect((thrown as ServerValidationError).validationErrors).toEqual(
+      validationBody('/contactEmail').data,
+    );
+  });
+
+  // The predicate is all-or-nothing on the returned paths: a caller that cannot
+  // render every one of them must keep the generic report instead.
+  it('rethrows unchanged when a path is not supported', () => {
+    const error = backendError(validationBody('/jobTitle'));
+
+    expect(capture(error)).toBe(error);
+  });
+
+  it('rethrows a non-BackendError unchanged', () => {
+    const error = new Error('boom');
+
+    expect(capture(error)).toBe(error);
+  });
+
+  // isValidationErrorResponse reads `.message` without a nil guard, and callers
+  // build the body from `resp.json().catch(() => undefined)`.
+  it.each([
+    ['the body is absent', undefined],
+    ['the body is not an object', 'upstream exploded'],
+    ['the body is null', null],
+    ['the body has no message', { statusCode: 400 }],
+    [
+      'the body has data but no message',
+      { statusCode: 400, data: [{ instancePath: '/contactEmail' }] },
+    ],
+    [
+      'data is not a list',
+      {
+        error: 'Bad Request',
+        message: 'Validation error',
+        statusCode: 400,
+        data: null,
+      },
+    ],
+    [
+      'the response is not a validation error',
+      {
+        error: 'Forbidden',
+        message: 'Forbidden',
+        statusCode: 403,
+      },
+    ],
+  ])('rethrows unchanged when %s', (_label, response) => {
+    const error = backendError(response);
+    const thrown = capture(error);
+
+    expect(thrown).toBe(error);
+    expect(thrown).not.toBeInstanceOf(TypeError);
   });
 });
 

--- a/packages/frontend-utils/src/api-util/api-util.ts
+++ b/packages/frontend-utils/src/api-util/api-util.ts
@@ -1,4 +1,9 @@
-import { ErrorResponse, ValidationErrorResponse } from '@asap-hub/model';
+import {
+  ErrorResponse,
+  isValidationErrorResponse,
+  ServerValidationError,
+  ValidationErrorResponse,
+} from '@asap-hub/model';
 import * as Sentry from '@sentry/react';
 
 export type GetListOptions = {
@@ -43,7 +48,10 @@ export class BackendError extends Error {
   public statusCode;
   constructor(
     message: string,
-    response: ErrorResponse | ValidationErrorResponse,
+    // Optional because a failing response may carry no JSON body at all —
+    // callers build this from `resp.json().catch(() => undefined)`, whose `any`
+    // let the non-optional type compile while lying to every reader.
+    response: ErrorResponse | ValidationErrorResponse | undefined,
     statusCode: number,
   ) {
     super(message);
@@ -60,6 +68,47 @@ export const validationErrorsAreSupported = (
   response.data.every(({ instancePath }) =>
     supportedErrorPaths.includes(instancePath),
   );
+
+/**
+ * The validation errors a rejection carries, when every one of them names a path
+ * the caller said it can render. `undefined` for anything else, so the caller
+ * falls back to whatever generic reporting it already had.
+ */
+export const getSupportedValidationErrors = (
+  error: unknown,
+  supportedErrors: string[],
+): ValidationErrorResponse['data'] | undefined => {
+  if (!(error instanceof BackendError)) return undefined;
+
+  const { response } = error;
+  // A failing response body is whatever it parsed to: absent when there was no
+  // JSON, or a bare string when it was not an object. Neither
+  // isValidationErrorResponse (reads `.message`) nor validationErrorsAreSupported
+  // (reads `.data.length`) guards for that.
+  return typeof response === 'object' &&
+    response !== null &&
+    typeof (response as ErrorResponse).message === 'string' &&
+    Array.isArray((response as ValidationErrorResponse).data) &&
+    isValidationErrorResponse(response) &&
+    validationErrorsAreSupported(response, supportedErrors)
+    ? response.data
+    : undefined;
+};
+
+/**
+ * Translates a backend validation response into a `ServerValidationError` so the
+ * form can surface it through the same path as its own field validation.
+ */
+export const toServerValidationError =
+  (supportedErrors: string[]) =>
+  (error: unknown): never => {
+    const validationErrors = getSupportedValidationErrors(
+      error,
+      supportedErrors,
+    );
+    if (validationErrors) throw new ServerValidationError(validationErrors);
+    throw error;
+  };
 
 export const clearAjvErrorForPath = (
   errors: ValidationErrorResponse['data'],

--- a/packages/gp2-components/src/index.ts
+++ b/packages/gp2-components/src/index.ts
@@ -22,6 +22,7 @@ export {
   BiographyModal,
   CardTable,
   ContactInformationModal,
+  contactInformationServerErrorPaths,
   ContributingCohortsModal,
   DashboardHeader,
   DashboardUserCard,

--- a/packages/gp2-components/src/organisms/ContactInformationModal.tsx
+++ b/packages/gp2-components/src/organisms/ContactInformationModal.tsx
@@ -1,12 +1,13 @@
-import { gp2 } from '@asap-hub/model';
+import { gp2, isServerValidationError } from '@asap-hub/model';
 import {
+  invalidEmailMessage,
   LabeledDropdown,
   LabeledTextField,
   pixels,
   FormSection,
 } from '@asap-hub/react-components';
 import {
-  emailExpression,
+  gp2EmailExpression,
   telephoneNumberExpression,
 } from '@asap-hub/validation';
 import { css } from '@emotion/react';
@@ -35,6 +36,10 @@ type ContactInformationModalProps = Pick<
     countryCodeSuggestions: { name: string; dialCode: string }[];
   };
 
+// Exported so the caller wiring toServerValidationError uses the same list this
+// modal can render. A path it cannot map produces a save that reports nothing.
+export const contactInformationServerErrorPaths = ['/alternativeEmail'];
+
 const ContactInformationModal: React.FC<ContactInformationModalProps> = ({
   onSave,
   backHref,
@@ -47,6 +52,7 @@ const ContactInformationModal: React.FC<ContactInformationModalProps> = ({
   const [newAlternativeEmail, setNewAlternativeEmail] = useState(
     alternativeEmail || '',
   );
+  const [serverError, setServerError] = useState('');
   const [newCountryCode, setNewCountryCode] = useState(
     telephone?.countryCode || '',
   );
@@ -62,13 +68,31 @@ const ContactInformationModal: React.FC<ContactInformationModalProps> = ({
       title="Contact Information"
       description="Provide alternative contact details."
       onSave={async () => {
-        await onSave({
-          alternativeEmail: newAlternativeEmail || null,
-          telephone: {
-            countryCode: newCountryCode || undefined,
-            number: newNumber || undefined,
-          },
-        });
+        setServerError('');
+        try {
+          await onSave({
+            alternativeEmail: newAlternativeEmail || null,
+            telephone: {
+              countryCode: newCountryCode || undefined,
+              number: newNumber || undefined,
+            },
+          });
+        } catch (error) {
+          if (!isServerValidationError(error)) throw error;
+
+          const rejectsTheEmail = error.validationErrors.some(
+            ({ instancePath }) => instancePath === '/alternativeEmail',
+          );
+          if (!rejectsTheEmail) {
+            // Nothing is on screen, and EditModal drops its toast for a
+            // ServerValidationError — so downgrade to keep the generic report.
+            throw new Error(error.message, { cause: error });
+          }
+
+          setServerError(invalidEmailMessage);
+          // EditModal treats a resolved promise as a save and navigates away.
+          throw error;
+        }
         void navigate(backHref);
       }}
       backHref={backHref}
@@ -90,10 +114,25 @@ const ContactInformationModal: React.FC<ContactInformationModalProps> = ({
               description="An alternative way for members to contact you. This will not affect the way that you login."
               enabled={!isSaving}
               value={newAlternativeEmail}
-              onChange={setNewAlternativeEmail}
+              onChange={(value) => {
+                setNewAlternativeEmail(value);
+                // A stale server error keeps the field DOM-invalid through
+                // setCustomValidity, and EditModal gates the save on
+                // reportValidity(), so it would block the next attempt.
+                setServerError('');
+              }}
+              customValidationMessage={serverError}
               type={'email'}
-              pattern={emailExpression}
-              getValidationMessage={() => 'Please enter a valid email address'}
+              // The browser ANDs its own address check with `pattern`, so this
+              // adds the content model's rule on top rather than replacing it:
+              // test@test passes the browser and fails here.
+              pattern={gp2EmailExpression}
+              // Defer to the browser's own message ("A part following '@'
+              // should not contain the symbol '+'.") and to the server's, both
+              // more specific than this one.
+              getValidationMessage={({ typeMismatch, customError }) =>
+                typeMismatch || customError ? undefined : invalidEmailMessage
+              }
             />
             <div css={telephoneContainerStyles}>
               <div css={css({ flex: `0 0 ${rem(208)}` })}>

--- a/packages/gp2-components/src/organisms/__tests__/ContactInformationModal.test.tsx
+++ b/packages/gp2-components/src/organisms/__tests__/ContactInformationModal.test.tsx
@@ -1,5 +1,7 @@
 import { mockActWarningsInConsole } from '@asap-hub/dom-test-utils';
 import { gp2 as gp2Fixtures } from '@asap-hub/fixtures';
+import { ServerValidationError } from '@asap-hub/model';
+import { invalidEmailMessage } from '@asap-hub/react-components';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
@@ -130,31 +132,165 @@ describe('ContactInformationModal', () => {
     });
     await waitFor(() => expect(getSaveButton()).toBeEnabled());
   });
-  it('does not allow invalid secondary email', async () => {
+
+  // test@test and the apostrophe satisfy the browser's own address check but not
+  // the GP2 content model, so before the pattern they reached Contentful.
+  it.each(['test@test', "o'brien@x.com"])(
+    'does not allow %p as a secondary email',
+    async (alternativeEmail) => {
+      const consoleErrorSpy = mockActWarningsInConsole('error');
+      const onSave = jest.fn();
+      renderContactInformation({
+        email: 'goncalo.ramos@fpf.pt',
+        alternativeEmail: '',
+        telephone: undefined,
+        onSave,
+      });
+
+      await userEvent.type(
+        screen.getByRole('textbox', {
+          name: /alternative email \(optional\)/i,
+        }),
+        alternativeEmail,
+      );
+
+      await userEvent.click(getSaveButton());
+      expect(screen.getByText(invalidEmailMessage)).toBeVisible();
+      expect(onSave).not.toHaveBeenCalled();
+      await waitFor(() => expect(getSaveButton()).toBeEnabled());
+      consoleErrorSpy.mockRestore();
+    },
+  );
+
+  // The API rejects what the browser cannot catch. Without this the save
+  // reported only the generic toast, with nothing marking the field.
+  // The browser's own messages name the actual fault, so `pattern` must not
+  // swallow them by reporting everything as a generic malformed address.
+  it('leaves the browser to explain the faults it catches itself', async () => {
     const consoleErrorSpy = mockActWarningsInConsole('error');
     const onSave = jest.fn();
-    const email = 'goncalo.ramos@fpf.pt';
-    const alternativeEmail = 'not-an-email-address';
     renderContactInformation({
-      email,
       alternativeEmail: '',
       telephone: undefined,
       onSave,
     });
 
-    await userEvent.type(
-      screen.getByRole('textbox', {
-        name: /alternative email \(optional\)/i,
-      }),
-      alternativeEmail,
-    );
-
+    const field = screen.getByRole('textbox', {
+      name: /alternative email \(optional\)/i,
+    }) as HTMLInputElement;
+    await userEvent.type(field, 'not-an-email-address');
     await userEvent.click(getSaveButton());
-    expect(
-      screen.getByText(/please enter a valid email address/i),
-    ).toBeVisible();
+
+    expect(field.validity.typeMismatch).toBe(true);
+    expect(screen.queryByText(invalidEmailMessage)).not.toBeInTheDocument();
     expect(onSave).not.toHaveBeenCalled();
-    await waitFor(() => expect(getSaveButton()).toBeEnabled());
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('shows the message on the field when the API rejects it', async () => {
+    const consoleErrorSpy = mockActWarningsInConsole('error');
+    renderContactInformation({
+      alternativeEmail: '',
+      telephone: undefined,
+      onSave: () =>
+        Promise.reject(
+          new ServerValidationError([
+            {
+              instancePath: '/alternativeEmail',
+              keyword: 'pattern',
+              params: {},
+              schemaPath: '#/properties/alternativeEmail/pattern',
+            },
+          ]),
+        ),
+    });
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /alternative email \(optional\)/i }),
+      'a@b.com',
+    );
+    await userEvent.click(getSaveButton());
+
+    expect(await screen.findByText(invalidEmailMessage)).toBeVisible();
+    // The field message is the whole report; the toast would be a second,
+    // vaguer message for the same problem.
+    expect(
+      screen.queryByText(/unable to save your changes/i),
+    ).not.toBeInTheDocument();
+    consoleErrorSpy.mockRestore();
+  });
+
+  // Anything the modal cannot pin to the field has to keep the toast, or the
+  // save fails with no signal at all.
+  // A rejection that is not a validation error at all — a network failure, say —
+  // must pass straight through to EditModal's generic report.
+  it('reports generically when the save fails for an unrelated reason', async () => {
+    const consoleErrorSpy = mockActWarningsInConsole('error');
+    renderContactInformation({
+      alternativeEmail: '',
+      telephone: undefined,
+      onSave: () => Promise.reject(new Error('network down')),
+    });
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /alternative email \(optional\)/i }),
+      'a@b.com',
+    );
+    await userEvent.click(getSaveButton());
+
+    expect(
+      await screen.findByText(/unable to save your changes/i),
+    ).toBeVisible();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('sends null when the field is cleared', async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    renderContactInformation({
+      alternativeEmail: 'previous@example.com',
+      telephone: undefined,
+      onSave,
+    });
+
+    await userEvent.clear(
+      screen.getByRole('textbox', { name: /alternative email \(optional\)/i }),
+    );
+    await userEvent.click(getSaveButton());
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({ alternativeEmail: null }),
+      ),
+    );
+  });
+
+  it('reports generically when the rejection names another field', async () => {
+    const consoleErrorSpy = mockActWarningsInConsole('error');
+    renderContactInformation({
+      alternativeEmail: '',
+      telephone: undefined,
+      onSave: () =>
+        Promise.reject(
+          new ServerValidationError([
+            {
+              instancePath: '/biography',
+              keyword: 'pattern',
+              params: {},
+              schemaPath: '#/properties/biography/pattern',
+            },
+          ]),
+        ),
+    });
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /alternative email \(optional\)/i }),
+      'a@b.com',
+    );
+    await userEvent.click(getSaveButton());
+
+    expect(
+      await screen.findByText(/unable to save your changes/i),
+    ).toBeVisible();
     consoleErrorSpy.mockRestore();
   });
 

--- a/packages/gp2-components/src/organisms/index.ts
+++ b/packages/gp2-components/src/organisms/index.ts
@@ -1,6 +1,9 @@
 export { default as BiographyModal } from './BiographyModal';
 export { default as CardTable } from './CardTable';
-export { default as ContactInformationModal } from './ContactInformationModal';
+export {
+  default as ContactInformationModal,
+  contactInformationServerErrorPaths,
+} from './ContactInformationModal';
 export { default as ContributingCohortsModal } from './ContributingCohortsModal';
 export { default as DashboardHeader } from './DashboardHeader';
 export { default as DashboardUserCard } from './DashboardUserCard';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -289,6 +289,8 @@ export {
   ComplianceDashboard,
   ComplianceReportForm,
   ContactInfoModal,
+  contactInfoServerErrorPaths,
+  invalidEmailMessage,
   ContentPage,
   CreateMilestoneModal,
   DashboardPage,

--- a/packages/react-components/src/organisms/EditModal.tsx
+++ b/packages/react-components/src/organisms/EditModal.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { ComponentProps, ReactNode, useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/react';
+import { isServerValidationError } from '@asap-hub/model';
 import { FormSection, Modal, ModalEditHeaderDecorator } from '../molecules';
 import { useNavigationWarning } from '../navigation';
 import { rem } from '../pixels';
@@ -68,9 +69,12 @@ const EditModal: React.FC<EditModalProps> = ({
         if (formRef.current) {
           setStatus('hasSaved');
         }
-      } catch {
+      } catch (error) {
         if (!formRef.current) return;
-        setStatus('hasError');
+        // A ServerValidationError means the form has already marked the
+        // offending field, so the generic toast would be a second, vaguer
+        // message for the same problem.
+        setStatus(isServerValidationError(error) ? 'initial' : 'hasError');
       }
     }
   };

--- a/packages/react-components/src/organisms/__tests__/EditModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/EditModal.test.tsx
@@ -1,6 +1,7 @@
 import { ComponentProps, ReactNode } from 'react';
 import { MemoryRouter, useLocation } from 'react-router';
 import { render, waitFor, screen } from '@testing-library/react';
+import { ServerValidationError } from '@asap-hub/model';
 import userEvent from '@testing-library/user-event';
 
 import { NavigationBlockerProvider } from '../../navigation';
@@ -279,6 +280,26 @@ describe('EditModal', () => {
           await waitFor(() =>
             expect(screen.getByTitle(/error icon/i)).toBeInTheDocument(),
           );
+        });
+
+        it('stays silent when the form already reported the failure on a field', async () => {
+          const handleSave = jest.fn().mockRejectedValueOnce(
+            new ServerValidationError([
+              {
+                instancePath: '/contactEmail',
+                keyword: 'pattern',
+                params: {},
+                schemaPath: '#/properties/contactEmail/pattern',
+              },
+            ]),
+          );
+          renderEditModal({ handleSave });
+
+          const saveButton = screen.getByRole('button', { name: 'Save' });
+          await userEvent.click(saveButton);
+
+          await waitFor(() => expect(saveButton).toBeEnabled());
+          expect(screen.queryByTitle(/error icon/i)).not.toBeInTheDocument();
         });
 
         it('re-enables the save button', async () => {

--- a/packages/react-components/src/templates/ContactInfoModal.tsx
+++ b/packages/react-components/src/templates/ContactInfoModal.tsx
@@ -1,5 +1,13 @@
-import { UserPatchRequest, UserResponse } from '@asap-hub/model';
-import { urlExpression, USER_SOCIAL_RESEARCHER_ID } from '@asap-hub/validation';
+import {
+  isServerValidationError,
+  UserPatchRequest,
+  UserResponse,
+} from '@asap-hub/model';
+import {
+  crnEmailExpression,
+  urlExpression,
+  USER_SOCIAL_RESEARCHER_ID,
+} from '@asap-hub/validation';
 import { css } from '@emotion/react';
 import { FunctionComponent, useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -18,6 +26,7 @@ import {
   XIcon,
 } from '../icons';
 import { mailToSupport } from '../mail';
+import { rem } from '../pixels';
 import { FormSection, LabeledTextField } from '../molecules';
 import { EditUserModal } from '../organisms';
 import { formatUserSocial, noop } from '../utils';
@@ -51,6 +60,45 @@ type ContactInfoModalProps = {
   readonly backHref: string;
   readonly onSave?: (data: UserPatchRequest) => void | Promise<void>;
 } & Pick<UserResponse, 'social'>;
+export const invalidEmailMessage =
+  'Enter a valid email address, for example name@gmail.com.';
+
+// Defer to the browser's own message ("A part following '@' should not contain
+// the symbol '+'.") and to the server's, both more specific than this one.
+const emailValidationMessage = ({
+  typeMismatch,
+  customError,
+}: ValidityState) =>
+  typeMismatch || customError ? undefined : invalidEmailMessage;
+
+// Gives the hint below the input 16 to clear the validation message, instead of
+// the 6 it uses when sitting directly under the input.
+//
+// Keyed on the message being non-empty rather than on `input:invalid`, which is
+// already true for a required field on first render and would move the hint with
+// nothing on screen. The message is the last div TextField renders after the
+// input, and it collapses when empty.
+// Wraps the field rather than reaching into LabeledTextField: its
+// `overrideStyles` prop is dead, and applying it would silently activate a
+// dormant style in DiscussionModal, which passes it too.
+const emailFieldStyles = css({
+  '> div:has(input ~ div:last-of-type:not(:empty)) > div:last-of-type': {
+    paddingTop: rem(16),
+  },
+});
+
+const emailFields = ['contactEmail', 'personalEmail'] as const;
+type EmailField = (typeof emailFields)[number];
+
+// Exported so the caller wiring toServerValidationError uses the same list this
+// modal can render. A path it cannot map produces a save that reports nothing.
+export const contactInfoServerErrorPaths = emailFields.map(
+  (field) => `/${field}`,
+);
+
+const emailFieldForInstancePath = (instancePath: string) =>
+  emailFields.find((field) => `/${field}` === instancePath);
+
 const ContactInfoModal: React.FC<ContactInfoModalProps> = ({
   email = '',
   personalEmail = '',
@@ -84,64 +132,132 @@ const ContactInfoModal: React.FC<ContactInfoModalProps> = ({
   const [newResearcherId, setNewResearcherId] = useState(researcherId);
   const [newTwitter, setNewTwitter] = useState(twitter);
   const [newBlueSky, setNewBlueSky] = useState(blueSky);
+  const [serverErrors, setServerErrors] = useState<
+    Partial<Record<EmailField, string>>
+  >({});
+
+  // Both fields clear, not just the edited one: a server error goes through
+  // setCustomValidity, and EditModal gates the whole save on reportValidity(),
+  // so a stale error on one email blocks the save that would report the other.
+  // The round-trip re-reports whatever is still wrong.
+  const clearServerErrors = () =>
+    setServerErrors((current) =>
+      Object.keys(current).length === 0 ? current : {},
+    );
 
   return (
     <EditUserModal
       backHref={backHref}
       title="Contact Details"
-      dirty={newEmail !== email || newPersonalEmail !== personalEmail}
+      // Every edited field, not just the emails: EditModal only warns on unsaved
+      // changes when `dirty`, so a narrower check loses a website edit silently
+      // once a rejected email puts the modal back in its `initial` state.
+      dirty={
+        newEmail !== email ||
+        newPersonalEmail !== personalEmail ||
+        newWebsite1 !== website1 ||
+        newWebsite2 !== website2 ||
+        newGithub !== github ||
+        newLinkedIn !== linkedIn ||
+        newGoogleScholar !== googleScholar ||
+        newResearchGate !== researchGate ||
+        newResearcherId !== researcherId ||
+        newTwitter !== twitter ||
+        newBlueSky !== blueSky
+      }
       onSave={async () => {
-        await onSave({
-          contactEmail: newEmail,
-          personalEmail: newPersonalEmail,
-          social: {
-            twitter: formatUserSocial(newTwitter, 'twitter') || undefined,
-            blueSky: formatUserSocial(newBlueSky, 'blueSky') || undefined,
-            researcherId: newResearcherId || undefined,
-            researchGate:
-              formatUserSocial(newResearchGate, 'researchGate') || undefined,
-            github: formatUserSocial(newGithub, 'github') || undefined,
-            googleScholar:
-              formatUserSocial(newGoogleScholar, 'googleScholar') || undefined,
-            linkedIn: formatUserSocial(newLinkedIn, 'linkedIn') || undefined,
-            website1: newWebsite1 || undefined,
-            website2: newWebsite2 || undefined,
-          },
-        });
+        clearServerErrors();
+        try {
+          await onSave({
+            contactEmail: newEmail,
+            personalEmail: newPersonalEmail,
+            social: {
+              twitter: formatUserSocial(newTwitter, 'twitter') || undefined,
+              blueSky: formatUserSocial(newBlueSky, 'blueSky') || undefined,
+              researcherId: newResearcherId || undefined,
+              researchGate:
+                formatUserSocial(newResearchGate, 'researchGate') || undefined,
+              github: formatUserSocial(newGithub, 'github') || undefined,
+              googleScholar:
+                formatUserSocial(newGoogleScholar, 'googleScholar') ||
+                undefined,
+              linkedIn: formatUserSocial(newLinkedIn, 'linkedIn') || undefined,
+              website1: newWebsite1 || undefined,
+              website2: newWebsite2 || undefined,
+            },
+          });
+        } catch (error) {
+          if (!isServerValidationError(error)) throw error;
+
+          const messages: Partial<Record<EmailField, string>> = {};
+          error.validationErrors.forEach(({ instancePath }) => {
+            const field = emailFieldForInstancePath(instancePath);
+            if (field) messages[field] = invalidEmailMessage;
+          });
+
+          if (Object.keys(messages).length === 0) {
+            // Nothing is on screen, and EditModal drops its toast for a
+            // ServerValidationError — so downgrade to keep the generic report.
+            throw new Error(error.message, { cause: error });
+          }
+
+          setServerErrors(messages);
+          // EditModal treats a resolved promise as a save and navigates away.
+          throw error;
+        }
         void navigate(backHref);
       }}
     >
       {({ isSaving }) => (
         <FormSection>
-          <LabeledTextField
-            type="email"
-            value={newEmail}
-            onChange={setNewEmail}
-            enabled={!isSaving}
-            title="Contact email"
-            subtitle="(optional)"
-            description={
-              <>
-                People in the ASAP Network will contact you using{' '}
-                <strong css={{ color: charcoal.rgb }}>{fallbackEmail}</strong>.
-                To use a different correspondence email address, please add it
-                below.
-              </>
-            }
-            hint="Note: This will not affect the way you login into the Hub."
-            placeholder="Add a different email"
-          />
-          <LabeledTextField
-            type="email"
-            value={newPersonalEmail}
-            onChange={setNewPersonalEmail}
-            enabled={!isSaving}
-            title="Personal Email"
-            subtitle="(optional)"
-            description="Enter a permanent personal email (e.g., Gmail or Yahoo) where we can reach you once you transition to a CRN alum. Because alumni lose access to the CRN Hub, ASAP staff may use this information to keep in touch."
-            hint="Note: This address is hidden from the community and will not appear on your profile. Only administrative staff will have access."
-            placeholder="Add a personal email"
-          />
+          <div css={emailFieldStyles}>
+            <LabeledTextField
+              type="email"
+              value={newEmail}
+              onChange={(value) => {
+                setNewEmail(value);
+                clearServerErrors();
+              }}
+              enabled={!isSaving}
+              // The browser ANDs its own address check with `pattern`, so this
+              // adds the content model's rule on top of type="email" rather than
+              // replacing it: test@test passes the browser and fails here.
+              pattern={crnEmailExpression}
+              customValidationMessage={serverErrors.contactEmail ?? ''}
+              getValidationMessage={emailValidationMessage}
+              title="Contact email"
+              subtitle="(optional)"
+              description={
+                <>
+                  People in the ASAP Network will contact you using{' '}
+                  <strong css={{ color: charcoal.rgb }}>{fallbackEmail}</strong>
+                  . To use a different correspondence email address, please add
+                  it below.
+                </>
+              }
+              hint="Note: This will not affect the way you login into the Hub."
+              placeholder="Add a different email"
+            />
+          </div>
+          <div css={emailFieldStyles}>
+            <LabeledTextField
+              type="email"
+              value={newPersonalEmail}
+              onChange={(value) => {
+                setNewPersonalEmail(value);
+                clearServerErrors();
+              }}
+              enabled={!isSaving}
+              pattern={crnEmailExpression}
+              customValidationMessage={serverErrors.personalEmail ?? ''}
+              getValidationMessage={emailValidationMessage}
+              title="Personal Email"
+              subtitle="(optional)"
+              description="Enter a permanent personal email (e.g., Gmail or Yahoo) where we can reach you once you transition to a CRN alum. Because alumni lose access to the CRN Hub, ASAP staff may use this information to keep in touch."
+              hint="Note: This address is hidden from the community and will not appear on your profile. Only administrative staff will have access."
+              placeholder="Add a personal email"
+            />
+          </div>
           <LabeledTextField
             title="Website 1"
             subtitle="(optional)"

--- a/packages/react-components/src/templates/__tests__/ContactInfoModal.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ContactInfoModal.test.tsx
@@ -2,9 +2,11 @@ import { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { render, act, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { UserResponse } from '@asap-hub/model';
+import { ServerValidationError, UserResponse } from '@asap-hub/model';
 
-import ContactInfoModal from '../ContactInfoModal';
+import ContactInfoModal, { invalidEmailMessage } from '../ContactInfoModal';
+import { NavigationBlockerProvider } from '../../navigation';
+import { rem } from '../../pixels';
 import { mockActErrorsInConsole } from '../../test-utils';
 
 const renderModal = (children: ReactNode) =>
@@ -163,6 +165,252 @@ it('does not fire onSave when the email is invalid', async () => {
   await userEvent.type(getByLabelText(/contact email/i), '.');
   await userEvent.click(getByText(/save/i));
   expect(handleSave).not.toHaveBeenCalled();
+});
+
+// test@test satisfies the browser's own address check but not the content
+// model, which requires a dot in the domain. It is the case this message
+// exists for: without it the save reached Contentful and came back generic.
+it.each(['Contact email', 'Personal Email'])(
+  'explains why %s was refused by the content model',
+  async (label) => {
+    const { getByLabelText, getByText } = renderModal(
+      <ContactInfoModal fallbackEmail="fallback@example.com" backHref="#" />,
+    );
+
+    await userEvent.type(getByLabelText(new RegExp(label)), 'test@test');
+    await userEvent.click(getByText(/save/i));
+
+    expect(getByText(invalidEmailMessage)).toBeVisible();
+  },
+);
+
+// The browser's own messages name the actual fault, so `pattern` must not
+// swallow them by reporting everything as a generic malformed address.
+it('leaves the browser to explain the faults it catches itself', async () => {
+  const { getByLabelText, getByText, queryByText } = renderModal(
+    <ContactInfoModal fallbackEmail="fallback@example.com" backHref="#" />,
+  );
+
+  const field = getByLabelText(/contact email/i) as HTMLInputElement;
+  await userEvent.type(field, 'not-an-email');
+  await userEvent.click(getByText(/save/i));
+
+  expect(field.validity.typeMismatch).toBe(true);
+  expect(queryByText(invalidEmailMessage)).not.toBeInTheDocument();
+});
+
+// The API rejects what the browser cannot catch — a value that reached it from
+// a stale client, or one Contentful's rule refuses for a reason the browser has
+// no opinion on. Without this the user got only the generic toast.
+it.each`
+  label               | otherLabel          | instancePath
+  ${'Contact email'}  | ${'Personal Email'} | ${'/contactEmail'}
+  ${'Personal Email'} | ${'Contact email'}  | ${'/personalEmail'}
+`(
+  'shows the message on $label when the API rejects $instancePath',
+  async ({ label, otherLabel, instancePath }) => {
+    const consoleMock = mockActErrorsInConsole();
+    const { getByLabelText, getByText, findByText, queryByText } = renderModal(
+      <ContactInfoModal
+        fallbackEmail="fallback@example.com"
+        backHref="#"
+        onSave={() =>
+          Promise.reject(
+            new ServerValidationError([
+              {
+                instancePath: instancePath as string,
+                keyword: 'pattern',
+                params: {},
+                schemaPath: `#/properties${instancePath}/pattern`,
+              },
+            ]),
+          )
+        }
+      />,
+    );
+
+    await userEvent.click(getByText(/save/i));
+
+    expect(await findByText(invalidEmailMessage)).toBeVisible();
+    const rejected = getByLabelText(new RegExp(label)) as HTMLInputElement;
+    const other = getByLabelText(new RegExp(otherLabel)) as HTMLInputElement;
+    expect(rejected.validationMessage).toBe(invalidEmailMessage);
+    expect(other.validationMessage).toBe('');
+    // The field message is the whole report; the toast would be a second,
+    // vaguer message for the same problem.
+    expect(queryByText(/unable to save your changes/i)).not.toBeInTheDocument();
+    consoleMock.mockRestore();
+  },
+);
+
+// A server error goes through setCustomValidity, and EditModal gates the whole
+// save on reportValidity(). Without clearing on edit, the stale error on the
+// first field blocks the save that would report the second.
+it('lets the next save through after filling the other email', async () => {
+  const consoleMock = mockActErrorsInConsole();
+  const reject = (...paths: string[]) =>
+    Promise.reject(
+      new ServerValidationError(
+        paths.map((instancePath) => ({
+          instancePath,
+          keyword: 'pattern',
+          params: {},
+          schemaPath: `#/properties${instancePath}/pattern`,
+        })),
+      ),
+    );
+  const onSave = jest
+    .fn()
+    .mockImplementationOnce(() => reject('/contactEmail'))
+    .mockImplementationOnce(() => reject('/contactEmail', '/personalEmail'));
+
+  const { getByLabelText, getByText, findByText, findAllByText } = renderModal(
+    <ContactInfoModal
+      fallbackEmail="fallback@example.com"
+      backHref="#"
+      onSave={onSave}
+    />,
+  );
+
+  // Both values pass the client rule, so only the API can object to them.
+  await userEvent.type(getByLabelText(/contact email/i), 'a@b.com');
+  await userEvent.click(getByText(/save/i));
+  expect(await findByText(invalidEmailMessage)).toBeVisible();
+
+  await userEvent.type(getByLabelText(/personal email/i), 'a@b.com');
+  await userEvent.click(getByText(/save/i));
+
+  expect(onSave).toHaveBeenCalledTimes(2);
+  expect(await findAllByText(invalidEmailMessage)).toHaveLength(2);
+  consoleMock.mockRestore();
+});
+
+// Anything the modal cannot pin to a field has to keep the toast, or the save
+// fails with no signal at all.
+// EditModal only warns about unsaved changes when `dirty`, and a rejected email
+// puts it back in the `initial` state — so a `dirty` that tracked only the
+// emails would drop an unsaved website edit with no prompt.
+it('still warns about an unsaved website after an email rejection', async () => {
+  const consoleMock = mockActErrorsInConsole();
+  const confirm = jest.spyOn(window, 'confirm').mockReturnValue(true);
+  const { getByLabelText, getByText, getByTitle } = render(
+    <MemoryRouter initialEntries={['/']}>
+      <NavigationBlockerProvider>
+        <ContactInfoModal
+          fallbackEmail="fallback@example.com"
+          backHref="#"
+          email="test@test"
+          onSave={() =>
+            Promise.reject(
+              new ServerValidationError([
+                {
+                  instancePath: '/contactEmail',
+                  keyword: 'pattern',
+                  params: {},
+                  schemaPath: '#/properties/contactEmail/pattern',
+                },
+              ]),
+            )
+          }
+        />
+      </NavigationBlockerProvider>
+    </MemoryRouter>,
+  );
+
+  await userEvent.type(getByLabelText(/website 1/i), 'https://example.com');
+  await userEvent.click(getByText(/save/i));
+  await waitFor(() => expect(getByText(/save/i)).toBeEnabled());
+
+  confirm.mockClear();
+  await userEvent.click(getByTitle(/close/i));
+
+  expect(confirm).toHaveBeenCalled();
+  consoleMock.mockRestore();
+  confirm.mockRestore();
+});
+
+// A rejection that is not a validation error at all — a network failure, say —
+// must pass straight through to EditModal's generic report.
+it('reports generically when the save fails for an unrelated reason', async () => {
+  const consoleMock = mockActErrorsInConsole();
+  const { getByText, findByText, queryByText } = renderModal(
+    <ContactInfoModal
+      fallbackEmail="fallback@example.com"
+      backHref="#"
+      onSave={() => Promise.reject(new Error('network down'))}
+    />,
+  );
+
+  await userEvent.click(getByText(/save/i));
+
+  expect(await findByText(/unable to save your changes/i)).toBeVisible();
+  expect(queryByText(invalidEmailMessage)).not.toBeInTheDocument();
+  consoleMock.mockRestore();
+});
+
+it('reports generically when the rejection names no field it can render', async () => {
+  const consoleMock = mockActErrorsInConsole();
+  const { getByText, findByText, queryByText } = renderModal(
+    <ContactInfoModal
+      fallbackEmail="fallback@example.com"
+      backHref="#"
+      onSave={() =>
+        Promise.reject(
+          new ServerValidationError([
+            {
+              instancePath: '/jobTitle',
+              keyword: 'pattern',
+              params: {},
+              schemaPath: '#/properties/jobTitle/pattern',
+            },
+          ]),
+        )
+      }
+    />,
+  );
+
+  await userEvent.click(getByText(/save/i));
+
+  expect(await findByText(/unable to save your changes/i)).toBeVisible();
+  expect(queryByText(invalidEmailMessage)).not.toBeInTheDocument();
+  consoleMock.mockRestore();
+});
+
+describe('spacing between the validation message and the hint', () => {
+  // Read the rule the modal actually emitted and ask whether it selects the
+  // hint. Comparing against a selector written here would pass no matter what
+  // the modal does.
+  const spacingRuleSelectsHint = (hint: HTMLElement) => {
+    const rule = [...document.querySelectorAll('style')]
+      .flatMap((style) => [...(style.sheet?.cssRules ?? [])])
+      .filter((cssRule): cssRule is CSSStyleRule => 'selectorText' in cssRule)
+      .find(({ cssText }) => cssText.includes(`padding-top: ${rem(16)}`));
+
+    return rule ? hint.matches(rule.selectorText) : false;
+  };
+
+  const contactHint = (getByText: (text: RegExp) => HTMLElement) =>
+    getByText(/^Note: This will not affect/);
+
+  it('leaves the hint alone while no message is showing', () => {
+    const { getByText } = renderModal(
+      <ContactInfoModal fallbackEmail="fallback@example.com" backHref="#" />,
+    );
+
+    expect(spacingRuleSelectsHint(contactHint(getByText))).toBe(false);
+  });
+
+  it('clears the message by 16 once one is showing', async () => {
+    const { getByLabelText, getByText } = renderModal(
+      <ContactInfoModal fallbackEmail="fallback@example.com" backHref="#" />,
+    );
+
+    await userEvent.type(getByLabelText(/contact email/i), 'test@test');
+    await userEvent.click(getByText(/save/i));
+
+    expect(getByText(invalidEmailMessage)).toBeVisible();
+    expect(spacingRuleSelectsHint(contactHint(getByText))).toBe(true);
+  });
 });
 
 it('disables the form elements while submitting', async () => {

--- a/packages/react-components/src/templates/index.ts
+++ b/packages/react-components/src/templates/index.ts
@@ -12,7 +12,11 @@ export { default as BasicLayout } from './BasicLayout';
 export { default as BiographyModal } from './BiographyModal';
 export { default as ComplianceDashboard } from './ComplianceDashboard';
 export { default as ComplianceReportForm } from './ComplianceReportForm';
-export { default as ContactInfoModal } from './ContactInfoModal';
+export {
+  default as ContactInfoModal,
+  contactInfoServerErrorPaths,
+  invalidEmailMessage,
+} from './ContactInfoModal';
 export { default as ContentPage } from './ContentPage';
 export { default as CreateMilestoneModal } from './CreateMilestoneModal';
 export { default as DashboardPage } from './DashboardPage';

--- a/packages/server-common/src/validation/validation.ts
+++ b/packages/server-common/src/validation/validation.ts
@@ -9,10 +9,27 @@ import Ajv, { JSONSchemaType, ValidateFunction } from 'ajv';
 import addFormats from 'ajv-formats';
 import { NullableOptionalProperties } from '../utils/types';
 
-const ajv = new Ajv({ useDefaults: true });
-const ajvCoerced = new Ajv({ coerceTypes: 'array', useDefaults: true });
-addFormats(ajv, ['date-time']);
-addFormats(ajvCoerced, ['date-time']);
+// One compiled instance per option set, created on first use. `allErrors` has
+// to be opt-in per schema rather than global: it makes AJV report every failure
+// instead of the first, which the Contact Details form needs to mark both email
+// fields at once, but which would change the error count for every other
+// schema in both servers.
+const ajvInstances = new Map<string, Ajv>();
+
+const ajvFor = ({ coerce = false, allErrors = false } = {}): Ajv => {
+  const key = `${coerce}:${allErrors}`;
+  const existing = ajvInstances.get(key);
+  if (existing) return existing;
+
+  const instance = new Ajv({
+    useDefaults: true,
+    allErrors,
+    ...(coerce ? { coerceTypes: 'array' as const } : {}),
+  });
+  addFormats(instance, ['date-time']);
+  ajvInstances.set(key, instance);
+  return instance;
+};
 
 // AJV requires setting every optional property nullable in the validatio schema
 // however marking it as nullable does not enforce the null types
@@ -30,6 +47,7 @@ export function validateInput<T, B extends boolean>(
   options?: {
     skipNull?: B;
     coerce?: boolean;
+    allErrors?: boolean;
     nullableKeys?: string[];
   },
 ): (
@@ -41,10 +59,11 @@ export function validateInput<T>(
   options?: {
     skipNull?: boolean;
     coerce?: boolean;
+    allErrors?: boolean;
     nullableKeys?: string[];
   },
 ): (data: Record<string, T>) => NonNullable<T> | NullableOptionalProperties<T> {
-  const ajvValidation = (options?.coerce ? ajvCoerced : ajv).compile(schema);
+  const ajvValidation = ajvFor(options).compile(schema);
 
   return (data) => {
     if (validate(ajvValidation, data)) {

--- a/packages/server-common/test/validation/validation.test.ts
+++ b/packages/server-common/test/validation/validation.test.ts
@@ -57,4 +57,51 @@ describe('Validate Input', () => {
     });
     expect(validateTestSchema({ param: null })).toEqual({ param: null });
   });
+
+  describe('allErrors', () => {
+    const twoFieldSchema: JSONSchemaType<{ one?: string; two?: string }> = {
+      type: 'object',
+      properties: {
+        one: { type: 'string', pattern: '^ok$', nullable: true },
+        two: { type: 'string', pattern: '^ok$', nullable: true },
+      },
+      additionalProperties: false,
+    };
+    const bothInvalid = { one: 'no', two: 'no' };
+
+    const paths = (validate: (data: Record<string, unknown>) => unknown) => {
+      try {
+        validate(bothInvalid);
+        return [];
+      } catch (error) {
+        return ((error as { data: { instancePath: string }[] }).data ?? []).map(
+          ({ instancePath }) => instancePath,
+        );
+      }
+    };
+
+    // Off by default, and it has to stay that way: validationErrorsAreSupported
+    // is all-or-nothing on the returned paths, so reporting more errors changes
+    // how every existing consumer behaves.
+    test('Should report only the first failure by default', () => {
+      expect(paths(validateInput(twoFieldSchema))).toEqual(['/one']);
+    });
+
+    test('Should report every failure when opted in', () => {
+      expect(paths(validateInput(twoFieldSchema, { allErrors: true }))).toEqual(
+        ['/one', '/two'],
+      );
+    });
+
+    // The instances are cached per option pair; asking for one combination must
+    // not hand back the instance compiled for another.
+    test('Should keep the setting separate from coerce', () => {
+      expect(
+        paths(validateInput(twoFieldSchema, { coerce: true, allErrors: true })),
+      ).toEqual(['/one', '/two']);
+      expect(paths(validateInput(twoFieldSchema, { coerce: true }))).toEqual([
+        '/one',
+      ]);
+    });
+  });
 });

--- a/packages/validation/src/__tests__/expressions.test.ts
+++ b/packages/validation/src/__tests__/expressions.test.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { crnEmailExpression, gp2EmailExpression } from '../expressions';
+
+describe('crnEmailExpression', () => {
+  const email = new RegExp(crnEmailExpression);
+
+  it.each([
+    'name@gmail.com',
+    'a.b+c@sub.domain.co.uk',
+    "o'brien@x.com",
+    'user_1@x-y.org',
+    'research_lab@my_uni.edu',
+  ])('should accept %s', (value) => {
+    expect(email.test(value)).toBe(true);
+  });
+
+  it('should accept the empty string, which clears an optional field', () => {
+    expect(email.test('')).toBe(true);
+  });
+
+  it.each([
+    ['test@test', 'the content model requires a dot in the domain'],
+    ['a!b@c.com', 'the content model disallows ! in the local part'],
+    ['.leading@dot.com', 'the local part may not start with a dot'],
+    ['not-an-email', 'there is no domain at all'],
+    ['a b@c.com', 'an address may not contain a space'],
+    [' ', 'a space is not an empty value'],
+  ])('should reject %p, because %s', (value) => {
+    expect(email.test(value)).toBe(false);
+  });
+
+  const addressOfLength = (length: number) =>
+    `${'a'.repeat(length - '@example.com'.length)}@example.com`;
+
+  it('should accept a value at the Contentful Symbol cap', () => {
+    expect(email.test(addressOfLength(256))).toBe(true);
+  });
+
+  it('should reject a value one character over the cap', () => {
+    expect(email.test(addressOfLength(257))).toBe(false);
+  });
+
+  // Without the length guard the domain repetition backtracks over the whole
+  // body and throws RangeError rather than returning false.
+  it('should not overflow the regexp stack on a runaway value', () => {
+    const runaway = `a@${'a.'.repeat(2_500_000)}!`;
+    expect(() => email.test(runaway)).not.toThrow();
+  });
+
+  it('should compile under the unicode flag AJV uses', () => {
+    expect(() => new RegExp(crnEmailExpression, 'u')).not.toThrow();
+  });
+});
+
+describe('parity with the CRN users content model', () => {
+  // The expression is a hand-copy of a string in another package, and nothing
+  // else here can observe the two drifting apart.
+  const migrationBody = "\\w[\\w.\\-+']*@([\\w-]+\\.)+[\\w-]+";
+
+  it.each([
+    '20230814130100-email-validation.js',
+    '20260727003012-add-personal-email-field.js',
+  ])('should match the validation written by %s', (migration) => {
+    const source = readFileSync(
+      join(__dirname, '../../../contentful/migrations/crn/users', migration),
+      'utf8',
+    );
+
+    // Every backslash is doubled in the migration's source literal.
+    expect(source).toContain(`^${migrationBody}$`.replace(/\\/g, '\\\\'));
+  });
+
+  // Reconstructed and compared whole rather than with toContain, which would
+  // also pass on an expression widened by alternation — the one drift this test
+  // exists to catch.
+  it('should wrap the migration body and nothing else', () => {
+    expect(crnEmailExpression).toBe(
+      `^(?=[\\s\\S]{0,256}$)(?:${migrationBody})?$`,
+    );
+  });
+});
+
+describe('gp2EmailExpression', () => {
+  const email = new RegExp(gp2EmailExpression);
+
+  it.each(['name@gmail.com', 'a.b+c@sub.domain.co.uk', 'user_1@x-y.org'])(
+    'should accept %s',
+    (value) => {
+      expect(email.test(value)).toBe(true);
+    },
+  );
+
+  it.each([
+    ["o'brien@x.com", 'the GP2 content model disallows the apostrophe'],
+    ['test@test', 'the content model requires a dot in the domain'],
+    ['', 'GP2 clears the field with null, not an empty string'],
+  ])('should reject %p, because %s', (value) => {
+    expect(email.test(value)).toBe(false);
+  });
+
+  it('should not overflow the regexp stack on a runaway value', () => {
+    expect(() => email.test(`a@${'a.'.repeat(2_500_000)}!`)).not.toThrow();
+  });
+});
+
+describe('parity with the GP2 users content model', () => {
+  const migrationBody = '\\w[\\w.\\-+]*@([\\w-]+\\.)+[\\w-]+';
+
+  it('should match the validation written by the users migration', () => {
+    const source = readFileSync(
+      join(
+        __dirname,
+        '../../../contentful/migrations/gp2/users',
+        '6ekgyp1432o9-create-users-1682073967694.js',
+      ),
+      'utf8',
+    );
+
+    expect(source).toContain(`^${migrationBody}$`.replace(/\\/g, '\\\\'));
+  });
+
+  it('should wrap the migration body and nothing else', () => {
+    expect(gp2EmailExpression).toBe(`^(?=[\\s\\S]{0,256}$)${migrationBody}$`);
+  });
+});

--- a/packages/validation/src/expressions.ts
+++ b/packages/validation/src/expressions.ts
@@ -1,10 +1,24 @@
-/* istanbul ignore file */
-
 export const urlExpression =
   "^(?:http(s)?:\\/\\/)[\\w.\\-]+(?:\\.[\\w\\.\\-]+)+[\\w\\-\\._~:\\/?#%\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$";
 
 export const emailExpression =
   "^[a-zA-Z0-9.!#$%&’*+\\/=?^_`'{|}~-]+@[a-zA-Z0-9-]+(?:.[a-zA-Z0-9-]+)*$";
+
+// The regexp validations on each product's user email fields, mirrored here so a
+// form refuses what Contentful would and the user sees the fault on blur rather
+// than after a round-trip. The two content models disagree — GP2 allows no
+// apostrophe — so neither product can borrow the other's rule.
+//
+// The lookahead in both is the `Symbol` cap. Without it the domain repetition
+// backtracks over a multi-megabyte body and throws RangeError out of the AJV
+// validator.
+//
+// Only CRN's trailing `?` admits '': its modal sends '' for a cleared field,
+// while GP2 sends null and lists alternativeEmail in nullableKeys.
+export const crnEmailExpression =
+  "^(?=[\\s\\S]{0,256}$)(?:\\w[\\w.\\-+']*@([\\w-]+\\.)+[\\w-]+)?$";
+export const gp2EmailExpression =
+  '^(?=[\\s\\S]{0,256}$)\\w[\\w.\\-+]*@([\\w-]+\\.)+[\\w-]+$';
 
 export const telephoneNumberExpression =
   '^\\(?\\d{3}\\)?[\\s.-]?\\d{3}[\\s.-]?\\d{3,4}$';

--- a/packages/validation/src/expressions.ts
+++ b/packages/validation/src/expressions.ts
@@ -1,9 +1,6 @@
 export const urlExpression =
   "^(?:http(s)?:\\/\\/)[\\w.\\-]+(?:\\.[\\w\\.\\-]+)+[\\w\\-\\._~:\\/?#%\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$";
 
-export const emailExpression =
-  "^[a-zA-Z0-9.!#$%&’*+\\/=?^_`'{|}~-]+@[a-zA-Z0-9-]+(?:.[a-zA-Z0-9-]+)*$";
-
 // The regexp validations on each product's user email fields, mirrored here so a
 // form refuses what Contentful would and the user sees the fault on blur rather
 // than after a round-trip. The two content models disagree — GP2 allows no


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/browse/ASAP-1636

A malformed email was accepted by the form and by the API, rejected by Contentful at the write, and shown as the generic "unable to save your changes" toast with no field marked.

Client-side faults show as soon as the field is left; a rejection that only the API can determine shows on save. When the API does reject a field, that field shows the error and the generic toast is suppressed.

### Decisions worth knowing

**`pattern` is added on top of `type="email"`, not instead of it**: the browser ANDs them. An earlier attempt to replace it with one wider expression never applied, because the browser's own check rejected values first.

**GP2 needs its own rule**: its content model disallows the apostrophe that CRN permits. 149,845 sampled values passed the GP2 form and API and were rejected at the write, `o'connor@a.com`(redacted) among them. Only Alternative Email is editable there, so `allErrors` is not needed.

**`allErrors` is opt-in per schema.**: by default AJV returned only `/contactEmail` when both emails were invalid, so the second field's fault was invisible. Enabling it globally would change the error count for every other schema.

### Recording

CRN:

https://github.com/user-attachments/assets/2839f8af-c51c-40fa-be19-fa21c4fb5b5c


GP2:

https://github.com/user-attachments/assets/0ac21c78-8df1-4881-a275-52273ce0a9c5

