### PR TITLE
[ASAP-1603] - Upload a List of Teams to Event Attendance

### DIFF
--- a/apps/crn-frontend/src/events/Event.tsx
+++ b/apps/crn-frontend/src/events/Event.tsx
@@ -25,7 +25,7 @@ import { useState } from 'react';
 
 import { downloadEventSpeakers } from './export';
 import { matchTeamNames } from './match-team-names';
-import { parseTeamNames } from './parse-team-list';
+import { parseTeamRows } from './parse-team-list';
 import {
   useEventById,
   useEventSpeakerGroups,
@@ -97,11 +97,11 @@ const Event: React.FC = () => {
             teams={teams}
             loadSearchOptions={async () => []}
             onUploadList={async (files: File[]) => {
-              const [names, corpus] = await Promise.all([
-                parseTeamNames(files),
+              const [rows, corpus] = await Promise.all([
+                parseTeamRows(files),
                 fetchTeamsForMatching(),
               ]);
-              return matchTeamNames(names, corpus, teams);
+              return matchTeamNames(rows, corpus, teams);
             }}
             onSave={async (updatedTeams: EventAttendanceTeam[]) => {
               await patchEvent({

--- a/apps/crn-frontend/src/events/Event.tsx
+++ b/apps/crn-frontend/src/events/Event.tsx
@@ -101,7 +101,7 @@ const Event: React.FC = () => {
                 parseTeamRows(files),
                 fetchTeamsForMatching(),
               ]);
-              return matchTeamNames(rows, corpus, teams);
+              return matchTeamNames(rows, corpus);
             }}
             onSave={async (updatedTeams: EventAttendanceTeam[]) => {
               await patchEvent({

--- a/apps/crn-frontend/src/events/Event.tsx
+++ b/apps/crn-frontend/src/events/Event.tsx
@@ -24,11 +24,14 @@ import { Frame, useBackHref } from '@asap-hub/frontend-utils';
 import { useState } from 'react';
 
 import { downloadEventSpeakers } from './export';
+import { matchTeamNames } from './match-team-names';
+import { parseTeamNames } from './parse-team-list';
 import {
   useEventById,
   useEventSpeakerGroups,
   usePatchEvent,
   useQuietRefreshEventById,
+  useTeamsForMatching,
 } from './state';
 
 const mapAttendanceTeams = (attendance: EventResponse['attendance'] = []) =>
@@ -51,6 +54,7 @@ const Event: React.FC = () => {
   const user = useCurrentUserCRN();
   const [isEditingAttendance, setIsEditingAttendance] = useState(false);
   const patchEvent = usePatchEvent(eventId);
+  const fetchTeamsForMatching = useTeamsForMatching();
 
   const hasFinished = useDateHasPassed(
     considerEndedAfter(event?.endDate || ''),
@@ -92,6 +96,13 @@ const Event: React.FC = () => {
           <EditEventAttendanceModal
             teams={teams}
             loadSearchOptions={async () => []}
+            onUploadList={async (files: File[]) => {
+              const [names, corpus] = await Promise.all([
+                parseTeamNames(files),
+                fetchTeamsForMatching(),
+              ]);
+              return matchTeamNames(names, corpus, teams);
+            }}
             onSave={async (updatedTeams: EventAttendanceTeam[]) => {
               await patchEvent({
                 attendance: updatedTeams.map((team) => ({

--- a/apps/crn-frontend/src/events/__mocks__/api.ts
+++ b/apps/crn-frontend/src/events/__mocks__/api.ts
@@ -1,7 +1,12 @@
-import { EventResponse, ListEventResponse } from '@asap-hub/model';
+import {
+  EventResponse,
+  ListEventResponse,
+  TeamListItemResponse,
+} from '@asap-hub/model';
 import {
   createEventResponse,
   createListEventResponse,
+  createTeamListItemResponse,
 } from '@asap-hub/fixtures';
 
 export const getEvent = jest.fn(
@@ -22,4 +27,8 @@ export const patchEvent = jest.fn(
     ...createEventResponse(),
     id,
   }),
+);
+
+export const getTeamsForMatching = jest.fn(
+  async (): Promise<TeamListItemResponse[]> => [createTeamListItemResponse()],
 );

--- a/apps/crn-frontend/src/events/__tests__/Event.test.tsx
+++ b/apps/crn-frontend/src/events/__tests__/Event.test.tsx
@@ -8,6 +8,7 @@ import {
   createCalendarResponse,
   createEventResponse,
   createInterestGroupResponse,
+  createTeamListItemResponse,
 } from '@asap-hub/fixtures';
 import { events } from '@asap-hub/routing';
 import { disable, enable } from '@asap-hub/flags';
@@ -19,7 +20,7 @@ import {
   WhenReady,
 } from '@asap-hub/crn-frontend/src/auth/test-utils';
 import Event from '../Event';
-import { getEvent, patchEvent } from '../api';
+import { getEvent, getTeamsForMatching, patchEvent } from '../api';
 import { downloadEventSpeakers } from '../export';
 
 jest.mock('../api');
@@ -39,10 +40,14 @@ const id = '42';
 
 const mockGetEvent = getEvent as jest.MockedFunction<typeof getEvent>;
 const mockPatchEvent = patchEvent as jest.MockedFunction<typeof patchEvent>;
+const mockGetTeamsForMatching = getTeamsForMatching as jest.MockedFunction<
+  typeof getTeamsForMatching
+>;
 beforeEach(() => {
   disable('NEW_EVENT_PAGE');
   mockGetEvent.mockClear();
   mockPatchEvent.mockClear();
+  mockGetTeamsForMatching.mockClear();
   mockGetEvent.mockResolvedValue({
     ...createEventResponse(),
     id,
@@ -384,6 +389,124 @@ describe('the NEW_EVENT_PAGE flag', () => {
       await userEvent.type(getByRole('combobox'), 'zzz');
 
       expect(await findByText('Sorry, no matches for zzz.')).toBeVisible();
+    });
+
+    describe('upload a list', () => {
+      const eventWithOneTeam = () => ({
+        ...createEventResponse(),
+        id,
+        endDate: pastEndDate,
+        attendance: [
+          {
+            id: 'attendance-1',
+            team: { id: 't1', displayName: 'Team One' },
+            attended: false,
+          },
+        ],
+      });
+
+      const openUploadList = async () => {
+        const rendered = render(<Event />, {
+          wrapper: createWrapper({ techSupport: true }),
+        });
+        await userEvent.click(
+          await rendered.findByRole('button', { name: 'Edit attendance' }),
+        );
+        await userEvent.click(
+          rendered.getByRole('button', { name: /Upload a List/i }),
+        );
+        return rendered;
+      };
+
+      const uploadCsv = async (container: HTMLElement, contents: string) => {
+        const fileInput = container.querySelector(
+          'input[type="file"]',
+        ) as HTMLInputElement;
+        await userEvent.upload(
+          fileInput,
+          new File([contents], 'teams.csv', { type: 'text/csv' }),
+        );
+      };
+
+      it('hides the upload entry point from a non tech support user', async () => {
+        mockGetEvent.mockResolvedValue(eventWithOneTeam());
+
+        const { findByText, queryByRole } = render(<Event />, {
+          wrapper: createWrapper(),
+        });
+
+        expect(await findByText('Team One')).toBeVisible();
+        expect(
+          queryByRole('button', { name: /Upload a List/i }),
+        ).not.toBeInTheDocument();
+      });
+
+      it('matches uploaded names and lists the ones the hub does not have', async () => {
+        mockGetEvent.mockResolvedValue(eventWithOneTeam());
+        mockGetTeamsForMatching.mockResolvedValue([
+          { ...createTeamListItemResponse(), id: 't2', displayName: 'Alessi' },
+        ]);
+
+        const { container, findByRole, findByText } = await openUploadList();
+        await uploadCsv(container, 'Team Name\nTeam Alessi\nNo Such Team\n');
+
+        expect(await findByText('2 Teams')).toBeVisible();
+        expect(
+          await findByRole('button', {
+            name: /will be added and marked if attended/,
+          }),
+        ).toBeVisible();
+        expect(await findByText(/1 not matched/)).toBeVisible();
+      });
+
+      it('counts a team already on the attendance list instead of adding it', async () => {
+        mockGetEvent.mockResolvedValue(eventWithOneTeam());
+        mockGetTeamsForMatching.mockResolvedValue([
+          {
+            ...createTeamListItemResponse(),
+            id: 't1',
+            displayName: 'Team One',
+          },
+        ]);
+
+        const { container, findByText } = await openUploadList();
+        await uploadCsv(container, 'Team Name\nTeam One\n');
+
+        expect(
+          await findByText(
+            'All 1 Teams in this list are already in the attendance table.',
+          ),
+        ).toBeVisible();
+      });
+
+      it('saves uploaded teams without an attendance id', async () => {
+        mockGetEvent.mockResolvedValue(eventWithOneTeam());
+        mockPatchEvent.mockResolvedValue({ ...createEventResponse(), id });
+        mockGetTeamsForMatching.mockResolvedValue([
+          { ...createTeamListItemResponse(), id: 't2', displayName: 'Alessi' },
+        ]);
+
+        const { container, findByRole, getByRole } = await openUploadList();
+        await uploadCsv(container, 'Team Name\nAlessi\n');
+
+        await userEvent.click(
+          await findByRole('button', { name: 'Add Attendees' }),
+        );
+        await userEvent.click(getByRole('button', { name: 'Save' }));
+
+        await waitFor(() =>
+          expect(mockPatchEvent).toHaveBeenCalledWith(
+            id,
+            {
+              attendance: [
+                { id: 'attendance-1', teamId: 't1', attended: false },
+                { id: undefined, teamId: 't2', attended: true },
+              ],
+            },
+            expect.anything(),
+          ),
+        );
+      });
     });
 
     it('closes the attendance modal without saving when dismissed', async () => {

--- a/apps/crn-frontend/src/events/__tests__/Event.test.tsx
+++ b/apps/crn-frontend/src/events/__tests__/Event.test.tsx
@@ -459,8 +459,9 @@ describe('the NEW_EVENT_PAGE flag', () => {
         expect(await findByText(/1 not matched/)).toBeVisible();
       });
 
-      it('counts a team already on the attendance list instead of adding it', async () => {
+      it('does not re-add a team already on the list but updates its status on save', async () => {
         mockGetEvent.mockResolvedValue(eventWithOneTeam());
+        mockPatchEvent.mockResolvedValue({ ...createEventResponse(), id });
         mockGetTeamsForMatching.mockResolvedValue([
           {
             ...createTeamListItemResponse(),
@@ -469,17 +470,35 @@ describe('the NEW_EVENT_PAGE flag', () => {
           },
         ]);
 
-        const { container, findByText } = await openUploadList();
-        await uploadCsv(container, 'Team Name\nTeam One\n');
+        const { container, findByText, findByRole, getByRole } =
+          await openUploadList();
+        await uploadCsv(container, 'Team Name,Attendance\nTeam One,Yes\n');
 
         expect(
           await findByText(
             'All 1 Teams in this list are already in the attendance table.',
           ),
         ).toBeVisible();
+
+        await userEvent.click(
+          await findByRole('button', { name: 'Add Attendees' }),
+        );
+        await userEvent.click(getByRole('button', { name: 'Save' }));
+
+        await waitFor(() =>
+          expect(mockPatchEvent).toHaveBeenCalledWith(
+            id,
+            {
+              attendance: [
+                { id: 'attendance-1', teamId: 't1', attended: true },
+              ],
+            },
+            expect.anything(),
+          ),
+        );
       });
 
-      it('saves uploaded teams without an attendance id', async () => {
+      it('saves a new uploaded team with its status and no attendance id', async () => {
         mockGetEvent.mockResolvedValue(eventWithOneTeam());
         mockPatchEvent.mockResolvedValue({ ...createEventResponse(), id });
         mockGetTeamsForMatching.mockResolvedValue([
@@ -487,7 +506,7 @@ describe('the NEW_EVENT_PAGE flag', () => {
         ]);
 
         const { container, findByRole, getByRole } = await openUploadList();
-        await uploadCsv(container, 'Team Name\nAlessi\n');
+        await uploadCsv(container, 'Team Name,Attendance\nAlessi,Yes\n');
 
         await userEvent.click(
           await findByRole('button', { name: 'Add Attendees' }),

--- a/apps/crn-frontend/src/events/__tests__/Event.test.tsx
+++ b/apps/crn-frontend/src/events/__tests__/Event.test.tsx
@@ -476,7 +476,7 @@ describe('the NEW_EVENT_PAGE flag', () => {
 
         expect(
           await findByText(
-            'All 1 Teams in this list are already in the attendance table.',
+            'All 1 team in this list is already in the attendance table.',
           ),
         ).toBeVisible();
 

--- a/apps/crn-frontend/src/events/__tests__/Event.test.tsx
+++ b/apps/crn-frontend/src/events/__tests__/Event.test.tsx
@@ -470,19 +470,16 @@ describe('the NEW_EVENT_PAGE flag', () => {
           },
         ]);
 
-        const { container, findByText, findByRole, getByRole } =
-          await openUploadList();
+        const { container, getByRole } = await openUploadList();
         await uploadCsv(container, 'Team Name,Attendance\nTeam One,Yes\n');
 
-        expect(
-          await findByText(
-            'All 1 team in this list is already in the attendance table.',
-          ),
-        ).toBeVisible();
-
-        await userEvent.click(
-          await findByRole('button', { name: 'Add Attendees' }),
+        // Enabled means the upload resolved the team; the wording it shows for
+        // an already-added one belongs to the modal's own test.
+        await waitFor(() =>
+          expect(getByRole('button', { name: 'Add Attendees' })).toBeEnabled(),
         );
+
+        await userEvent.click(getByRole('button', { name: 'Add Attendees' }));
         await userEvent.click(getByRole('button', { name: 'Save' }));
 
         await waitFor(() =>

--- a/apps/crn-frontend/src/events/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/events/__tests__/api.test.ts
@@ -6,11 +6,12 @@ import {
 import {
   createEventResponse,
   createListEventResponse,
+  createTeamListItemResponse,
 } from '@asap-hub/fixtures';
 import { getEventListOptions } from '@asap-hub/frontend-utils';
 import nock from 'nock';
 import { API_BASE_URL } from '../../config';
-import { getEvent, getEvents, patchEvent } from '../api';
+import { getEvent, getEvents, getTeamsForMatching, patchEvent } from '../api';
 
 jest.mock('../../config');
 
@@ -275,5 +276,70 @@ describe('getEvents', () => {
       },
       false,
     );
+  });
+});
+
+describe('getTeamsForMatching', () => {
+  type Search = ClientSearch<'crn', 'team'>;
+  const search: jest.MockedFunction<Search> = jest.fn();
+
+  const algoliaSearchClient = {
+    search,
+  } as unknown as AlgoliaSearchClient<'crn'>;
+
+  const hit = (index: number) =>
+    ({
+      ...createTeamListItemResponse(index),
+      objectID: `t${index}`,
+      __meta: { type: 'team' as const },
+    }) as unknown as Awaited<ReturnType<Search>>['hits'][number];
+
+  beforeEach(() => {
+    search.mockReset();
+  });
+
+  it('fetches the whole team corpus in a single query', async () => {
+    search.mockResolvedValueOnce(
+      createAlgoliaResponse<'crn', 'team'>([hit(0), hit(1)]),
+    );
+
+    const teams = await getTeamsForMatching(algoliaSearchClient);
+
+    expect(teams).toHaveLength(2);
+    expect(search).toHaveBeenCalledTimes(1);
+    expect(search).toHaveBeenCalledWith(
+      ['team'],
+      '',
+      expect.objectContaining({ hitsPerPage: 1000, page: 0 }),
+    );
+  });
+
+  it('pages until the whole corpus is collected', async () => {
+    search
+      .mockResolvedValueOnce(
+        createAlgoliaResponse<'crn', 'team'>([hit(0)], { nbHits: 2 }),
+      )
+      .mockResolvedValueOnce(
+        createAlgoliaResponse<'crn', 'team'>([hit(1)], { nbHits: 2 }),
+      );
+
+    const teams = await getTeamsForMatching(algoliaSearchClient);
+
+    expect(teams.map(({ id }) => id)).toEqual(['t0', 't1']);
+    expect(search).toHaveBeenCalledTimes(2);
+    expect(search).toHaveBeenLastCalledWith(
+      ['team'],
+      '',
+      expect.objectContaining({ page: 1 }),
+    );
+  });
+
+  it('stops when the corpus is empty', async () => {
+    search.mockResolvedValueOnce(
+      createAlgoliaResponse<'crn', 'team'>([], { nbHits: 5 }),
+    );
+
+    await expect(getTeamsForMatching(algoliaSearchClient)).resolves.toEqual([]);
+    expect(search).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/crn-frontend/src/events/__tests__/match-team-names.test.ts
+++ b/apps/crn-frontend/src/events/__tests__/match-team-names.test.ts
@@ -1,0 +1,134 @@
+import { createTeamListItemResponse } from '@asap-hub/fixtures';
+import { TeamListItemResponse } from '@asap-hub/model';
+import { EventAttendanceTeam } from '@asap-hub/react-components';
+
+import { matchTeamNames, normalizeTeamName } from '../match-team-names';
+
+const team = (
+  overrides: Partial<TeamListItemResponse> = {},
+): TeamListItemResponse => ({
+  ...createTeamListItemResponse(),
+  id: 't-alessi',
+  displayName: 'Alessi',
+  teamType: 'Discovery Team',
+  ...overrides,
+});
+
+const attendanceRow = (teamId: string): EventAttendanceTeam => ({
+  teamId,
+  teamName: teamId,
+  attended: true,
+});
+
+describe('normalizeTeamName', () => {
+  it.each`
+    input             | expected
+    ${'  Alessi  '}   | ${'alessi'}
+    ${'ALESSI'}       | ${'alessi'}
+    ${'Team Alessi'}  | ${'alessi'}
+    ${'team  alessi'} | ${'alessi'}
+    ${'Alessi Team'}  | ${'alessi team'}
+    ${'Teamwork'}     | ${'teamwork'}
+  `('Should normalize $input to $expected', ({ input, expected }) => {
+    expect(normalizeTeamName(input)).toEqual(expected);
+  });
+});
+
+describe('matchTeamNames', () => {
+  it('Should match a name exactly', () => {
+    const result = matchTeamNames(['Alessi'], [team()], []);
+
+    expect(result.matched).toEqual([
+      {
+        teamId: 't-alessi',
+        teamName: 'Alessi',
+        attended: true,
+        teamType: 'Discovery Team',
+        isTeamInactive: false,
+      },
+    ]);
+    expect(result.unmatched).toEqual([]);
+    expect(result.alreadyInCount).toEqual(0);
+  });
+
+  it.each(['Team Alessi', 'ALESSI', '  alessi  '])(
+    'Should match %s against the stored display name',
+    (name) => {
+      const result = matchTeamNames([name], [team()], []);
+
+      expect(result.matched).toHaveLength(1);
+      expect(result.unmatched).toEqual([]);
+    },
+  );
+
+  it('Should list a name with no match, without a suggestion', () => {
+    const result = matchTeamNames([' Alessy '], [team()], []);
+
+    expect(result.matched).toEqual([]);
+    expect(result.unmatched).toEqual([{ name: 'Alessy' }]);
+    expect(result.unmatched[0]?.suggestion).toBeUndefined();
+  });
+
+  it('Should count an already added team instead of matching it', () => {
+    const result = matchTeamNames(
+      ['Alessi'],
+      [team()],
+      [attendanceRow('t-alessi')],
+    );
+
+    expect(result.matched).toEqual([]);
+    expect(result.alreadyInCount).toEqual(1);
+    expect(result.unmatched).toEqual([]);
+  });
+
+  it('Should keep the three sets disjoint so the summary total adds up', () => {
+    const teams = [
+      team(),
+      team({ id: 't-aguzzi', displayName: 'Aguzzi' }),
+      team({ id: 't-chen', displayName: 'Chen' }),
+    ];
+
+    const result = matchTeamNames(
+      ['Alessi', 'Aguzzi', 'Chen', 'Nobody'],
+      teams,
+      [attendanceRow('t-chen')],
+    );
+
+    expect(result.matched.map(({ teamName }) => teamName)).toEqual([
+      'Alessi',
+      'Aguzzi',
+    ]);
+    expect(result.alreadyInCount).toEqual(1);
+    expect(result.unmatched).toEqual([{ name: 'Nobody' }]);
+    expect(
+      result.matched.length + result.alreadyInCount + result.unmatched.length,
+    ).toEqual(4);
+  });
+
+  it('Should count a repeated name once', () => {
+    const result = matchTeamNames(
+      ['Alessi', 'Team Alessi', 'ALESSI', 'Ghost', 'ghost'],
+      [team()],
+      [],
+    );
+
+    expect(result.matched).toHaveLength(1);
+    expect(result.unmatched).toEqual([{ name: 'Ghost' }]);
+  });
+
+  it('Should skip blank names', () => {
+    const result = matchTeamNames(['   ', ''], [team()], []);
+
+    expect(result).toEqual({ matched: [], alreadyInCount: 0, unmatched: [] });
+  });
+
+  it('Should match an inactive team and flag it', () => {
+    const result = matchTeamNames(
+      ['Alessi'],
+      [team({ inactiveSince: '2024-01-01T00:00:00.000Z' })],
+      [],
+    );
+
+    expect(result.matched[0]?.isTeamInactive).toEqual(true);
+  });
+});

--- a/apps/crn-frontend/src/events/__tests__/match-team-names.test.ts
+++ b/apps/crn-frontend/src/events/__tests__/match-team-names.test.ts
@@ -3,6 +3,7 @@ import { TeamListItemResponse } from '@asap-hub/model';
 import { EventAttendanceTeam } from '@asap-hub/react-components';
 
 import { matchTeamNames, normalizeTeamName } from '../match-team-names';
+import { ParsedTeamRow } from '../parse-team-list';
 
 const team = (
   overrides: Partial<TeamListItemResponse> = {},
@@ -14,10 +15,18 @@ const team = (
   ...overrides,
 });
 
-const attendanceRow = (teamId: string): EventAttendanceTeam => ({
+const row = (name: string, attended = false): ParsedTeamRow => ({
+  name,
+  attended,
+});
+
+const attendanceRow = (
+  teamId: string,
+  attended = true,
+): EventAttendanceTeam => ({
   teamId,
   teamName: teamId,
-  attended: true,
+  attended,
 });
 
 describe('normalizeTeamName', () => {
@@ -35,8 +44,8 @@ describe('normalizeTeamName', () => {
 });
 
 describe('matchTeamNames', () => {
-  it('Should match a name exactly', () => {
-    const result = matchTeamNames(['Alessi'], [team()], []);
+  it('Should match a name and carry its uploaded attendance status', () => {
+    const result = matchTeamNames([row('Alessi', true)], [team()], []);
 
     expect(result.matched).toEqual([
       {
@@ -47,14 +56,20 @@ describe('matchTeamNames', () => {
         isTeamInactive: false,
       },
     ]);
+    expect(result.alreadyIn).toEqual([]);
     expect(result.unmatched).toEqual([]);
-    expect(result.alreadyInCount).toEqual(0);
+  });
+
+  it('Should match a name marked not attended', () => {
+    const result = matchTeamNames([row('Alessi', false)], [team()], []);
+
+    expect(result.matched[0]?.attended).toEqual(false);
   });
 
   it.each(['Team Alessi', 'ALESSI', '  alessi  '])(
     'Should match %s against the stored display name',
     (name) => {
-      const result = matchTeamNames([name], [team()], []);
+      const result = matchTeamNames([row(name)], [team()], []);
 
       expect(result.matched).toHaveLength(1);
       expect(result.unmatched).toEqual([]);
@@ -62,22 +77,30 @@ describe('matchTeamNames', () => {
   );
 
   it('Should list a name with no match, without a suggestion', () => {
-    const result = matchTeamNames([' Alessy '], [team()], []);
+    const result = matchTeamNames([row(' Alessy ')], [team()], []);
 
     expect(result.matched).toEqual([]);
     expect(result.unmatched).toEqual([{ name: 'Alessy' }]);
     expect(result.unmatched[0]?.suggestion).toBeUndefined();
   });
 
-  it('Should count an already added team instead of matching it', () => {
+  it('Should put an already-listed team into alreadyIn with the uploaded status', () => {
     const result = matchTeamNames(
-      ['Alessi'],
+      [row('Alessi', false)],
       [team()],
-      [attendanceRow('t-alessi')],
+      [attendanceRow('t-alessi', true)],
     );
 
     expect(result.matched).toEqual([]);
-    expect(result.alreadyInCount).toEqual(1);
+    expect(result.alreadyIn).toEqual([
+      {
+        teamId: 't-alessi',
+        teamName: 'Alessi',
+        attended: false,
+        teamType: 'Discovery Team',
+        isTeamInactive: false,
+      },
+    ]);
     expect(result.unmatched).toEqual([]);
   });
 
@@ -89,7 +112,7 @@ describe('matchTeamNames', () => {
     ];
 
     const result = matchTeamNames(
-      ['Alessi', 'Aguzzi', 'Chen', 'Nobody'],
+      [row('Alessi', true), row('Aguzzi'), row('Chen', true), row('Nobody')],
       teams,
       [attendanceRow('t-chen')],
     );
@@ -98,33 +121,36 @@ describe('matchTeamNames', () => {
       'Alessi',
       'Aguzzi',
     ]);
-    expect(result.alreadyInCount).toEqual(1);
+    expect(result.alreadyIn.map(({ teamName }) => teamName)).toEqual(['Chen']);
     expect(result.unmatched).toEqual([{ name: 'Nobody' }]);
     expect(
-      result.matched.length + result.alreadyInCount + result.unmatched.length,
+      result.matched.length +
+        result.alreadyIn.length +
+        result.unmatched.length,
     ).toEqual(4);
   });
 
-  it('Should count a repeated name once', () => {
+  it('Should keep the first occurrence of a repeated name', () => {
     const result = matchTeamNames(
-      ['Alessi', 'Team Alessi', 'ALESSI', 'Ghost', 'ghost'],
+      [row('Alessi', true), row('Team Alessi', false), row('Ghost'), row('ghost')],
       [team()],
       [],
     );
 
     expect(result.matched).toHaveLength(1);
+    expect(result.matched[0]?.attended).toEqual(true);
     expect(result.unmatched).toEqual([{ name: 'Ghost' }]);
   });
 
   it('Should skip blank names', () => {
-    const result = matchTeamNames(['   ', ''], [team()], []);
+    const result = matchTeamNames([row('   '), row('')], [team()], []);
 
-    expect(result).toEqual({ matched: [], alreadyInCount: 0, unmatched: [] });
+    expect(result).toEqual({ matched: [], alreadyIn: [], unmatched: [] });
   });
 
   it('Should match an inactive team and flag it', () => {
     const result = matchTeamNames(
-      ['Alessi'],
+      [row('Alessi')],
       [team({ inactiveSince: '2024-01-01T00:00:00.000Z' })],
       [],
     );

--- a/apps/crn-frontend/src/events/__tests__/match-team-names.test.ts
+++ b/apps/crn-frontend/src/events/__tests__/match-team-names.test.ts
@@ -1,6 +1,5 @@
 import { createTeamListItemResponse } from '@asap-hub/fixtures';
 import { TeamListItemResponse } from '@asap-hub/model';
-import { EventAttendanceTeam } from '@asap-hub/react-components';
 
 import { matchTeamNames, normalizeTeamName } from '../match-team-names';
 import { ParsedTeamRow } from '../parse-team-list';
@@ -20,15 +19,6 @@ const row = (name: string, attended = false): ParsedTeamRow => ({
   attended,
 });
 
-const attendanceRow = (
-  teamId: string,
-  attended = true,
-): EventAttendanceTeam => ({
-  teamId,
-  teamName: teamId,
-  attended,
-});
-
 describe('normalizeTeamName', () => {
   it.each`
     input             | expected
@@ -45,7 +35,7 @@ describe('normalizeTeamName', () => {
 
 describe('matchTeamNames', () => {
   it('Should match a name and carry its uploaded attendance status', () => {
-    const result = matchTeamNames([row('Alessi', true)], [team()], []);
+    const result = matchTeamNames([row('Alessi', true)], [team()]);
 
     expect(result.matched).toEqual([
       {
@@ -56,12 +46,11 @@ describe('matchTeamNames', () => {
         isTeamInactive: false,
       },
     ]);
-    expect(result.alreadyIn).toEqual([]);
     expect(result.unmatched).toEqual([]);
   });
 
   it('Should match a name marked not attended', () => {
-    const result = matchTeamNames([row('Alessi', false)], [team()], []);
+    const result = matchTeamNames([row('Alessi', false)], [team()]);
 
     expect(result.matched[0]?.attended).toEqual(false);
   });
@@ -69,7 +58,7 @@ describe('matchTeamNames', () => {
   it.each(['Team Alessi', 'ALESSI', '  alessi  '])(
     'Should match %s against the stored display name',
     (name) => {
-      const result = matchTeamNames([row(name)], [team()], []);
+      const result = matchTeamNames([row(name)], [team()]);
 
       expect(result.matched).toHaveLength(1);
       expect(result.unmatched).toEqual([]);
@@ -77,34 +66,14 @@ describe('matchTeamNames', () => {
   );
 
   it('Should list a name with no match, without a suggestion', () => {
-    const result = matchTeamNames([row(' Alessy ')], [team()], []);
+    const result = matchTeamNames([row(' Alessy ')], [team()]);
 
     expect(result.matched).toEqual([]);
     expect(result.unmatched).toEqual([{ name: 'Alessy' }]);
     expect(result.unmatched[0]?.suggestion).toBeUndefined();
   });
 
-  it('Should put an already-listed team into alreadyIn with the uploaded status', () => {
-    const result = matchTeamNames(
-      [row('Alessi', false)],
-      [team()],
-      [attendanceRow('t-alessi', true)],
-    );
-
-    expect(result.matched).toEqual([]);
-    expect(result.alreadyIn).toEqual([
-      {
-        teamId: 't-alessi',
-        teamName: 'Alessi',
-        attended: false,
-        teamType: 'Discovery Team',
-        isTeamInactive: false,
-      },
-    ]);
-    expect(result.unmatched).toEqual([]);
-  });
-
-  it('Should keep the three sets disjoint so the summary total adds up', () => {
+  it('Should resolve every Hub team into matched regardless of the current table', () => {
     const teams = [
       team(),
       team({ id: 't-aguzzi', displayName: 'Aguzzi' }),
@@ -114,27 +83,26 @@ describe('matchTeamNames', () => {
     const result = matchTeamNames(
       [row('Alessi', true), row('Aguzzi'), row('Chen', true), row('Nobody')],
       teams,
-      [attendanceRow('t-chen')],
     );
 
     expect(result.matched.map(({ teamName }) => teamName)).toEqual([
       'Alessi',
       'Aguzzi',
+      'Chen',
     ]);
-    expect(result.alreadyIn.map(({ teamName }) => teamName)).toEqual(['Chen']);
     expect(result.unmatched).toEqual([{ name: 'Nobody' }]);
-    expect(
-      result.matched.length +
-        result.alreadyIn.length +
-        result.unmatched.length,
-    ).toEqual(4);
+    expect(result.matched.length + result.unmatched.length).toEqual(4);
   });
 
   it('Should keep the first occurrence of a repeated name', () => {
     const result = matchTeamNames(
-      [row('Alessi', true), row('Team Alessi', false), row('Ghost'), row('ghost')],
+      [
+        row('Alessi', true),
+        row('Team Alessi', false),
+        row('Ghost'),
+        row('ghost'),
+      ],
       [team()],
-      [],
     );
 
     expect(result.matched).toHaveLength(1);
@@ -143,16 +111,15 @@ describe('matchTeamNames', () => {
   });
 
   it('Should skip blank names', () => {
-    const result = matchTeamNames([row('   '), row('')], [team()], []);
+    const result = matchTeamNames([row('   '), row('')], [team()]);
 
-    expect(result).toEqual({ matched: [], alreadyIn: [], unmatched: [] });
+    expect(result).toEqual({ matched: [], unmatched: [] });
   });
 
   it('Should match an inactive team and flag it', () => {
     const result = matchTeamNames(
       [row('Alessi')],
       [team({ inactiveSince: '2024-01-01T00:00:00.000Z' })],
-      [],
     );
 
     expect(result.matched[0]?.isTeamInactive).toEqual(true);

--- a/apps/crn-frontend/src/events/__tests__/match-team-names.test.ts
+++ b/apps/crn-frontend/src/events/__tests__/match-team-names.test.ts
@@ -34,26 +34,23 @@ describe('normalizeTeamName', () => {
 });
 
 describe('matchTeamNames', () => {
-  it('Should match a name and carry its uploaded attendance status', () => {
-    const result = matchTeamNames([row('Alessi', true)], [team()]);
+  it.each([true, false])(
+    'Should match a name and carry attended=%s from the file',
+    (attended) => {
+      const result = matchTeamNames([row('Alessi', attended)], [team()]);
 
-    expect(result.matched).toEqual([
-      {
-        teamId: 't-alessi',
-        teamName: 'Alessi',
-        attended: true,
-        teamType: 'Discovery Team',
-        isTeamInactive: false,
-      },
-    ]);
-    expect(result.unmatched).toEqual([]);
-  });
-
-  it('Should match a name marked not attended', () => {
-    const result = matchTeamNames([row('Alessi', false)], [team()]);
-
-    expect(result.matched[0]?.attended).toEqual(false);
-  });
+      expect(result.matched).toEqual([
+        {
+          teamId: 't-alessi',
+          teamName: 'Alessi',
+          attended,
+          teamType: 'Discovery Team',
+          isTeamInactive: false,
+        },
+      ]);
+      expect(result.unmatched).toEqual([]);
+    },
+  );
 
   it.each(['Team Alessi', 'ALESSI', '  alessi  '])(
     'Should match %s against the stored display name',

--- a/apps/crn-frontend/src/events/__tests__/match-team-names.test.ts
+++ b/apps/crn-frontend/src/events/__tests__/match-team-names.test.ts
@@ -113,6 +113,24 @@ describe('matchTeamNames', () => {
     expect(result).toEqual({ matched: [], unmatched: [] });
   });
 
+  it('Should keep two Hub teams distinct when they differ only by a leading Team prefix', () => {
+    const teams = [
+      team({ id: 't-science', displayName: 'Science' }),
+      team({ id: 't-team-science', displayName: 'Team Science' }),
+    ];
+
+    const result = matchTeamNames(
+      [row('Science', true), row('Team Science', false)],
+      teams,
+    );
+
+    expect(result.matched).toEqual([
+      expect.objectContaining({ teamId: 't-science', attended: true }),
+      expect.objectContaining({ teamId: 't-team-science', attended: false }),
+    ]);
+    expect(result.unmatched).toEqual([]);
+  });
+
   it('Should match an inactive team and flag it', () => {
     const result = matchTeamNames(
       [row('Alessi')],

--- a/apps/crn-frontend/src/events/__tests__/parse-team-list.test.ts
+++ b/apps/crn-frontend/src/events/__tests__/parse-team-list.test.ts
@@ -172,6 +172,34 @@ describe('parseSheet', () => {
       ]);
     });
 
+    it('Should read a Y/N column in a file with no headers at all', () => {
+      expect(parseSheet('Aguzzi,Y\nAlessi,N\nChen,Y\n')).toEqual([
+        { name: 'Aguzzi', attended: true },
+        { name: 'Alessi', attended: false },
+        { name: 'Chen', attended: true },
+      ]);
+    });
+
+    it('Should sniff a headerless status column past the second one', () => {
+      expect(parseSheet('Aguzzi,a@b.com,Yes\n')).toEqual([
+        { name: 'Aguzzi', attended: true },
+      ]);
+    });
+
+    it('Should leave a headerless non-status column alone', () => {
+      expect(parseSheet('Aguzzi,a@b.com\nAlessi,c@d.com\n')).toEqual([
+        { name: 'Aguzzi', attended: false },
+        { name: 'Alessi', attended: false },
+      ]);
+    });
+
+    it('Should skip a blank column to reach the real status column', () => {
+      expect(parseSheet('Aguzzi,,Yes\nAlessi,,No\n')).toEqual([
+        { name: 'Aguzzi', attended: true },
+        { name: 'Alessi', attended: false },
+      ]);
+    });
+
     it('Should read a status column when the team column has no header', () => {
       expect(
         parseSheet(

--- a/apps/crn-frontend/src/events/__tests__/parse-team-list.test.ts
+++ b/apps/crn-frontend/src/events/__tests__/parse-team-list.test.ts
@@ -1,6 +1,6 @@
 import * as XLSX from 'xlsx';
 
-import { parseSheet, parseTeamNames } from '../parse-team-list';
+import { parseSheet, parseTeamRows } from '../parse-team-list';
 
 const toXlsxBuffer = (rows: unknown[][]): ArrayBuffer => {
   const workbook = XLSX.utils.book_new();
@@ -20,6 +20,9 @@ const xlsxFile = (rows: unknown[][], name = 'teams.xlsx') =>
     type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   });
 
+const names = (rows: ReturnType<typeof parseSheet>) =>
+  rows.map(({ name }) => name);
+
 const realFileReader = window.FileReader;
 
 const withFailingFileReader = (error: Error | null) => {
@@ -35,46 +38,48 @@ afterEach(() => {
 
 describe('parseSheet', () => {
   it('Should read a CSV with a Team Name header', () => {
-    expect(parseSheet('Team Name\nAguzzi\nTeam Alessi\n')).toEqual([
+    expect(names(parseSheet('Team Name\nAguzzi\nTeam Alessi\n'))).toEqual([
       'Aguzzi',
       'Team Alessi',
     ]);
   });
 
   it('Should treat the first row as data when no header is recognised', () => {
-    expect(parseSheet('Aguzzi\nAlessi\n')).toEqual(['Aguzzi', 'Alessi']);
+    expect(names(parseSheet('Aguzzi\nAlessi\n'))).toEqual(['Aguzzi', 'Alessi']);
   });
 
   it('Should accept Team and Teams as header aliases', () => {
-    expect(parseSheet('Team\nAguzzi\n')).toEqual(['Aguzzi']);
-    expect(parseSheet('  TEAMS  \nAguzzi\n')).toEqual(['Aguzzi']);
+    expect(names(parseSheet('Team\nAguzzi\n'))).toEqual(['Aguzzi']);
+    expect(names(parseSheet('  TEAMS  \nAguzzi\n'))).toEqual(['Aguzzi']);
   });
 
   it('Should use the headed column when it is not the first one', () => {
     expect(
-      parseSheet('Email,Team Name\na@b.com,Aguzzi\nc@d.com,Alessi\n'),
+      names(parseSheet('Email,Team Name\na@b.com,Aguzzi\nc@d.com,Alessi\n')),
     ).toEqual(['Aguzzi', 'Alessi']);
   });
 
   it('Should keep a quoted comma inside a single name', () => {
-    expect(parseSheet('Team Name\n"Aguzzi, Alessi"\n')).toEqual([
+    expect(names(parseSheet('Team Name\n"Aguzzi, Alessi"\n'))).toEqual([
       'Aguzzi, Alessi',
     ]);
   });
 
   it('Should read a semicolon delimited CSV', () => {
-    expect(parseSheet('Email;Team Name\na@b.com;Aguzzi\n')).toEqual(['Aguzzi']);
+    expect(names(parseSheet('Email;Team Name\na@b.com;Aguzzi\n'))).toEqual([
+      'Aguzzi',
+    ]);
   });
 
   it('Should tolerate a BOM and CRLF line endings', () => {
-    expect(parseSheet('﻿Team Name\r\nAguzzi\r\nAlessi\r\n')).toEqual([
+    expect(names(parseSheet('﻿Team Name\r\nAguzzi\r\nAlessi\r\n'))).toEqual([
       'Aguzzi',
       'Alessi',
     ]);
   });
 
   it('Should skip empty rows and blank cells', () => {
-    expect(parseSheet('Team Name\nAguzzi\n\n   \nAlessi\n')).toEqual([
+    expect(names(parseSheet('Team Name\nAguzzi\n\n   \nAlessi\n'))).toEqual([
       'Aguzzi',
       'Alessi',
     ]);
@@ -82,16 +87,18 @@ describe('parseSheet', () => {
 
   it('Should read an XLSX file', () => {
     expect(
-      parseSheet(toXlsxBuffer([['Team Name'], ['Aguzzi'], ['Alessi']])),
+      names(parseSheet(toXlsxBuffer([['Team Name'], ['Aguzzi'], ['Alessi']]))),
     ).toEqual(['Aguzzi', 'Alessi']);
   });
 
   it('Should read numeric team names as text', () => {
-    expect(parseSheet(toXlsxBuffer([['Team Name'], [42]]))).toEqual(['42']);
+    expect(names(parseSheet(toXlsxBuffer([['Team Name'], [42]])))).toEqual([
+      '42',
+    ]);
   });
 
   it('Should treat a non-text header cell as no header at all', () => {
-    expect(parseSheet(toXlsxBuffer([[42], ['Aguzzi']]))).toEqual([
+    expect(names(parseSheet(toXlsxBuffer([[42], ['Aguzzi']])))).toEqual([
       '42',
       'Aguzzi',
     ]);
@@ -99,6 +106,62 @@ describe('parseSheet', () => {
 
   it('Should return nothing for a sheet with no rows', () => {
     expect(parseSheet('')).toEqual([]);
+  });
+
+  describe('attendance status', () => {
+    it('Should default to not attended when there is no status column', () => {
+      expect(parseSheet('Team Name\nAguzzi\n')).toEqual([
+        { name: 'Aguzzi', attended: false },
+      ]);
+    });
+
+    it.each`
+      cell          | attended
+      ${'Yes'}      | ${true}
+      ${'yes'}      | ${true}
+      ${'Y'}        | ${true}
+      ${'TRUE'}     | ${true}
+      ${'1'}        | ${true}
+      ${'Attended'} | ${true}
+      ${'Present'}  | ${true}
+      ${'No'}       | ${false}
+      ${'n'}        | ${false}
+      ${'FALSE'}    | ${false}
+      ${'0'}        | ${false}
+      ${''}         | ${false}
+      ${'maybe'}    | ${false}
+    `(
+      'Should read attendance cell "$cell" as attended=$attended',
+      ({ cell, attended }) => {
+        expect(
+          parseSheet(`Team Name,Attendance\nAguzzi,${cell}\n`),
+        ).toEqual([{ name: 'Aguzzi', attended }]);
+      },
+    );
+
+    it('Should accept Attended, Status and Present as status headers', () => {
+      expect(parseSheet('Team Name,Attended\nAguzzi,Yes\n')).toEqual([
+        { name: 'Aguzzi', attended: true },
+      ]);
+      expect(parseSheet('Team Name,Status\nAguzzi,Yes\n')).toEqual([
+        { name: 'Aguzzi', attended: true },
+      ]);
+      expect(parseSheet('Team,Present\nAguzzi,No\n')).toEqual([
+        { name: 'Aguzzi', attended: false },
+      ]);
+    });
+
+    it('Should read the status column even when it comes first', () => {
+      expect(parseSheet('Attendance,Team Name\nYes,Aguzzi\n')).toEqual([
+        { name: 'Aguzzi', attended: true },
+      ]);
+    });
+
+    it('Should read a status column when the team column has no header', () => {
+      expect(parseSheet(toXlsxBuffer([[42, 'Attendance'], ['Aguzzi', 'Yes']]))).toEqual(
+        [{ name: 'Aguzzi', attended: true }],
+      );
+    });
   });
 
   it('Should ignore every sheet after the first', () => {
@@ -115,12 +178,10 @@ describe('parseSheet', () => {
     );
 
     expect(
-      parseSheet(XLSX.write(workbook, { type: 'array', bookType: 'xlsx' })),
+      names(parseSheet(XLSX.write(workbook, { type: 'array', bookType: 'xlsx' }))),
     ).toEqual(['Aguzzi']);
   });
 
-  // XLSX.read always yields at least one sheet, so the guard against a
-  // sheetless workbook is only reachable with the reader stubbed out.
   it('Should return nothing for a workbook with no sheet', async () => {
     jest.resetModules();
     jest.doMock('xlsx', () => ({
@@ -136,25 +197,28 @@ describe('parseSheet', () => {
   });
 });
 
-describe('parseTeamNames', () => {
-  it('Should concatenate names across files in order', async () => {
+describe('parseTeamRows', () => {
+  it('Should concatenate rows across files in order', async () => {
     await expect(
-      parseTeamNames([
-        csvFile('Team Name\nAguzzi\n', 'first.csv'),
+      parseTeamRows([
+        csvFile('Team Name,Attendance\nAguzzi,Yes\n', 'first.csv'),
         xlsxFile([['Team Name'], ['Alessi']], 'second.xlsx'),
       ]),
-    ).resolves.toEqual(['Aguzzi', 'Alessi']);
+    ).resolves.toEqual([
+      { name: 'Aguzzi', attended: true },
+      { name: 'Alessi', attended: false },
+    ]);
   });
 
   it('Should return nothing when no files are given', async () => {
-    await expect(parseTeamNames([])).resolves.toEqual([]);
+    await expect(parseTeamRows([])).resolves.toEqual([]);
   });
 
   it('Should reject with the error the reader reports', async () => {
     const error = new Error('unreadable');
     withFailingFileReader(error);
 
-    await expect(parseTeamNames([csvFile('Team Name\nAguzzi\n')])).rejects.toBe(
+    await expect(parseTeamRows([csvFile('Team Name\nAguzzi\n')])).rejects.toBe(
       error,
     );
   });
@@ -163,7 +227,7 @@ describe('parseTeamNames', () => {
     withFailingFileReader(null);
 
     await expect(
-      parseTeamNames([csvFile('Team Name\nAguzzi\n', 'broken.csv')]),
+      parseTeamRows([csvFile('Team Name\nAguzzi\n', 'broken.csv')]),
     ).rejects.toThrow('Could not read broken.csv');
   });
 });

--- a/apps/crn-frontend/src/events/__tests__/parse-team-list.test.ts
+++ b/apps/crn-frontend/src/events/__tests__/parse-team-list.test.ts
@@ -1,0 +1,169 @@
+import * as XLSX from 'xlsx';
+
+import { parseSheet, parseTeamNames } from '../parse-team-list';
+
+const toXlsxBuffer = (rows: unknown[][]): ArrayBuffer => {
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(
+    workbook,
+    XLSX.utils.aoa_to_sheet(rows),
+    'Sheet1',
+  );
+  return XLSX.write(workbook, { type: 'array', bookType: 'xlsx' });
+};
+
+const csvFile = (contents: string, name = 'teams.csv') =>
+  new File([contents], name, { type: 'text/csv' });
+
+const xlsxFile = (rows: unknown[][], name = 'teams.xlsx') =>
+  new File([toXlsxBuffer(rows)], name, {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  });
+
+const realFileReader = window.FileReader;
+
+const withFailingFileReader = (error: Error | null) => {
+  window.FileReader = function StubFileReader(this: Record<string, unknown>) {
+    this.error = error;
+    this.readAsText = () => (this.onerror as () => void)();
+  } as unknown as typeof FileReader;
+};
+
+afterEach(() => {
+  window.FileReader = realFileReader;
+});
+
+describe('parseSheet', () => {
+  it('Should read a CSV with a Team Name header', () => {
+    expect(parseSheet('Team Name\nAguzzi\nTeam Alessi\n')).toEqual([
+      'Aguzzi',
+      'Team Alessi',
+    ]);
+  });
+
+  it('Should treat the first row as data when no header is recognised', () => {
+    expect(parseSheet('Aguzzi\nAlessi\n')).toEqual(['Aguzzi', 'Alessi']);
+  });
+
+  it('Should accept Team and Teams as header aliases', () => {
+    expect(parseSheet('Team\nAguzzi\n')).toEqual(['Aguzzi']);
+    expect(parseSheet('  TEAMS  \nAguzzi\n')).toEqual(['Aguzzi']);
+  });
+
+  it('Should use the headed column when it is not the first one', () => {
+    expect(
+      parseSheet('Email,Team Name\na@b.com,Aguzzi\nc@d.com,Alessi\n'),
+    ).toEqual(['Aguzzi', 'Alessi']);
+  });
+
+  it('Should keep a quoted comma inside a single name', () => {
+    expect(parseSheet('Team Name\n"Aguzzi, Alessi"\n')).toEqual([
+      'Aguzzi, Alessi',
+    ]);
+  });
+
+  it('Should read a semicolon delimited CSV', () => {
+    expect(parseSheet('Email;Team Name\na@b.com;Aguzzi\n')).toEqual(['Aguzzi']);
+  });
+
+  it('Should tolerate a BOM and CRLF line endings', () => {
+    expect(parseSheet('﻿Team Name\r\nAguzzi\r\nAlessi\r\n')).toEqual([
+      'Aguzzi',
+      'Alessi',
+    ]);
+  });
+
+  it('Should skip empty rows and blank cells', () => {
+    expect(parseSheet('Team Name\nAguzzi\n\n   \nAlessi\n')).toEqual([
+      'Aguzzi',
+      'Alessi',
+    ]);
+  });
+
+  it('Should read an XLSX file', () => {
+    expect(
+      parseSheet(toXlsxBuffer([['Team Name'], ['Aguzzi'], ['Alessi']])),
+    ).toEqual(['Aguzzi', 'Alessi']);
+  });
+
+  it('Should read numeric team names as text', () => {
+    expect(parseSheet(toXlsxBuffer([['Team Name'], [42]]))).toEqual(['42']);
+  });
+
+  it('Should treat a non-text header cell as no header at all', () => {
+    expect(parseSheet(toXlsxBuffer([[42], ['Aguzzi']]))).toEqual([
+      '42',
+      'Aguzzi',
+    ]);
+  });
+
+  it('Should return nothing for a sheet with no rows', () => {
+    expect(parseSheet('')).toEqual([]);
+  });
+
+  it('Should ignore every sheet after the first', () => {
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(
+      workbook,
+      XLSX.utils.aoa_to_sheet([['Team Name'], ['Aguzzi']]),
+      'First',
+    );
+    XLSX.utils.book_append_sheet(
+      workbook,
+      XLSX.utils.aoa_to_sheet([['Team Name'], ['Ignored']]),
+      'Second',
+    );
+
+    expect(
+      parseSheet(XLSX.write(workbook, { type: 'array', bookType: 'xlsx' })),
+    ).toEqual(['Aguzzi']);
+  });
+
+  // XLSX.read always yields at least one sheet, so the guard against a
+  // sheetless workbook is only reachable with the reader stubbed out.
+  it('Should return nothing for a workbook with no sheet', async () => {
+    jest.resetModules();
+    jest.doMock('xlsx', () => ({
+      ...jest.requireActual('xlsx'),
+      read: () => ({ SheetNames: [], Sheets: {} }),
+    }));
+
+    const isolated = await import('../parse-team-list');
+    expect(isolated.parseSheet('')).toEqual([]);
+
+    jest.dontMock('xlsx');
+    jest.resetModules();
+  });
+});
+
+describe('parseTeamNames', () => {
+  it('Should concatenate names across files in order', async () => {
+    await expect(
+      parseTeamNames([
+        csvFile('Team Name\nAguzzi\n', 'first.csv'),
+        xlsxFile([['Team Name'], ['Alessi']], 'second.xlsx'),
+      ]),
+    ).resolves.toEqual(['Aguzzi', 'Alessi']);
+  });
+
+  it('Should return nothing when no files are given', async () => {
+    await expect(parseTeamNames([])).resolves.toEqual([]);
+  });
+
+  it('Should reject with the error the reader reports', async () => {
+    const error = new Error('unreadable');
+    withFailingFileReader(error);
+
+    await expect(parseTeamNames([csvFile('Team Name\nAguzzi\n')])).rejects.toBe(
+      error,
+    );
+  });
+
+  it('Should reject with a fallback error when the reader gives none', async () => {
+    withFailingFileReader(null);
+
+    await expect(
+      parseTeamNames([csvFile('Team Name\nAguzzi\n', 'broken.csv')]),
+    ).rejects.toThrow('Could not read broken.csv');
+  });
+});

--- a/apps/crn-frontend/src/events/__tests__/parse-team-list.test.ts
+++ b/apps/crn-frontend/src/events/__tests__/parse-team-list.test.ts
@@ -106,7 +106,11 @@ describe('parseSheet', () => {
 
   it('Should return nothing for a sheet that has no rows', () => {
     const workbook = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(workbook, XLSX.utils.aoa_to_sheet([]), 'Empty');
+    XLSX.utils.book_append_sheet(
+      workbook,
+      XLSX.utils.aoa_to_sheet([]),
+      'Empty',
+    );
 
     expect(
       parseSheet(XLSX.write(workbook, { type: 'array', bookType: 'xlsx' })),

--- a/apps/crn-frontend/src/events/__tests__/parse-team-list.test.ts
+++ b/apps/crn-frontend/src/events/__tests__/parse-team-list.test.ts
@@ -133,9 +133,9 @@ describe('parseSheet', () => {
     `(
       'Should read attendance cell "$cell" as attended=$attended',
       ({ cell, attended }) => {
-        expect(
-          parseSheet(`Team Name,Attendance\nAguzzi,${cell}\n`),
-        ).toEqual([{ name: 'Aguzzi', attended }]);
+        expect(parseSheet(`Team Name,Attendance\nAguzzi,${cell}\n`)).toEqual([
+          { name: 'Aguzzi', attended },
+        ]);
       },
     );
 
@@ -157,10 +157,21 @@ describe('parseSheet', () => {
       ]);
     });
 
+    it('Should not read the status column as team names when the team header is unrecognised', () => {
+      expect(parseSheet('Attendance,Owner\nYes,Aguzzi\n')).toEqual([
+        { name: 'Aguzzi', attended: true },
+      ]);
+    });
+
     it('Should read a status column when the team column has no header', () => {
-      expect(parseSheet(toXlsxBuffer([[42, 'Attendance'], ['Aguzzi', 'Yes']]))).toEqual(
-        [{ name: 'Aguzzi', attended: true }],
-      );
+      expect(
+        parseSheet(
+          toXlsxBuffer([
+            [42, 'Attendance'],
+            ['Aguzzi', 'Yes'],
+          ]),
+        ),
+      ).toEqual([{ name: 'Aguzzi', attended: true }]);
     });
   });
 
@@ -178,7 +189,9 @@ describe('parseSheet', () => {
     );
 
     expect(
-      names(parseSheet(XLSX.write(workbook, { type: 'array', bookType: 'xlsx' }))),
+      names(
+        parseSheet(XLSX.write(workbook, { type: 'array', bookType: 'xlsx' })),
+      ),
     ).toEqual(['Aguzzi']);
   });
 

--- a/apps/crn-frontend/src/events/__tests__/parse-team-list.test.ts
+++ b/apps/crn-frontend/src/events/__tests__/parse-team-list.test.ts
@@ -104,8 +104,13 @@ describe('parseSheet', () => {
     ]);
   });
 
-  it('Should return nothing for a sheet with no rows', () => {
-    expect(parseSheet('')).toEqual([]);
+  it('Should return nothing for a sheet that has no rows', () => {
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, XLSX.utils.aoa_to_sheet([]), 'Empty');
+
+    expect(
+      parseSheet(XLSX.write(workbook, { type: 'array', bookType: 'xlsx' })),
+    ).toEqual([]);
   });
 
   describe('attendance status', () => {

--- a/apps/crn-frontend/src/events/__tests__/state.test.tsx
+++ b/apps/crn-frontend/src/events/__tests__/state.test.tsx
@@ -3,21 +3,26 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, render, renderHook, waitFor } from '@testing-library/react';
 import { Component, ReactNode, Suspense } from 'react';
 
-import { createEventResponse } from '@asap-hub/fixtures';
+import {
+  createEventResponse,
+  createTeamListItemResponse,
+} from '@asap-hub/fixtures';
 
 import { Auth0Provider, WhenReady } from '../../auth/test-utils';
-import { getEvent, getEvents } from '../api';
+import { getEvent, getEvents, getTeamsForMatching } from '../api';
 import {
   eventQueryKeys,
   useEventById,
   useEvents,
   useEventSpeakerGroups,
   useQuietRefreshEventById,
+  useTeamsForMatching,
 } from '../state';
 
 jest.mock('../api', () => ({
   getEvent: jest.fn(),
   getEvents: jest.fn(),
+  getTeamsForMatching: jest.fn(),
   patchEvent: jest.fn(),
 }));
 
@@ -188,3 +193,38 @@ const EventsProbe = () => {
   useEvents(listOptions);
   return <>rendered</>;
 };
+
+describe('useTeamsForMatching', () => {
+  const mockGetTeamsForMatching = getTeamsForMatching as jest.MockedFunction<
+    typeof getTeamsForMatching
+  >;
+
+  beforeEach(() => {
+    mockGetTeamsForMatching.mockReset();
+    mockGetTeamsForMatching.mockResolvedValue([createTeamListItemResponse()]);
+  });
+
+  it('does not fetch the corpus until it is called', async () => {
+    const queryClient = createTestQueryClient();
+    renderHook(() => useTeamsForMatching(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(mockGetTeamsForMatching).not.toHaveBeenCalled());
+  });
+
+  it('fetches the corpus once and caches it across calls', async () => {
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useTeamsForMatching(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current).toBeDefined());
+
+    const first = await result.current();
+    const second = await result.current();
+
+    expect(first).toEqual(second);
+    expect(mockGetTeamsForMatching).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/crn-frontend/src/events/api.ts
+++ b/apps/crn-frontend/src/events/api.ts
@@ -99,9 +99,9 @@ export const getTeamsForMatching = async (
 ): Promise<TeamListItemResponse[]> => {
   const items: TeamListItemResponse[] = [];
   let currentPage = 0;
-  let total = 0;
+  let total = Infinity;
 
-  do {
+  while (items.length < total) {
     // eslint-disable-next-line no-await-in-loop
     const result = await getAlgoliaTeams(algoliaClient, {
       searchQuery: '',
@@ -109,10 +109,14 @@ export const getTeamsForMatching = async (
       currentPage,
       pageSize: teamsForMatchingPageSize,
     });
+    // Guard against a page that returns nothing so the loop always terminates.
+    if (result.items.length === 0) {
+      break;
+    }
     items.push(...result.items);
     total = result.total;
     currentPage += 1;
-  } while (items.length < total && items.length > 0);
+  }
 
   return items;
 };

--- a/apps/crn-frontend/src/events/api.ts
+++ b/apps/crn-frontend/src/events/api.ts
@@ -92,8 +92,7 @@ export const patchEvent = async (
   return resp.json();
 };
 
-// One Algolia pass per upload instead of one query per uploaded name: the whole
-// corpus is resolved in memory by matchTeamNames.
+// Fetch the whole team corpus once per upload; matchTeamNames resolves in memory.
 export const getTeamsForMatching = async (
   algoliaClient: AlgoliaClient<'crn'>,
 ): Promise<TeamListItemResponse[]> => {

--- a/apps/crn-frontend/src/events/api.ts
+++ b/apps/crn-frontend/src/events/api.ts
@@ -98,24 +98,25 @@ export const getTeamsForMatching = async (
   algoliaClient: AlgoliaClient<'crn'>,
 ): Promise<TeamListItemResponse[]> => {
   const items: TeamListItemResponse[] = [];
-  let currentPage = 0;
   let total = Infinity;
 
-  while (items.length < total) {
+  for (let currentPage = 0; items.length < total; currentPage += 1) {
     // eslint-disable-next-line no-await-in-loop
-    const result = await getAlgoliaTeams(algoliaClient, {
-      searchQuery: '',
-      teamType: 'all',
-      currentPage,
-      pageSize: teamsForMatchingPageSize,
-    });
-    // Guard against a page that returns nothing so the loop always terminates.
-    if (result.items.length === 0) {
+    const { items: pageItems, total: pageTotal } = await getAlgoliaTeams(
+      algoliaClient,
+      {
+        searchQuery: '',
+        teamType: 'all',
+        currentPage,
+        pageSize: teamsForMatchingPageSize,
+      },
+    );
+    // An empty page guarantees termination even if total is off.
+    if (pageItems.length === 0) {
       break;
     }
-    items.push(...result.items);
-    total = result.total;
-    currentPage += 1;
+    items.push(...pageItems);
+    total = pageTotal;
   }
 
   return items;

--- a/apps/crn-frontend/src/events/api.ts
+++ b/apps/crn-frontend/src/events/api.ts
@@ -8,8 +8,12 @@ import {
   EventResponse,
   EventUpdateDetailsRequest,
   ListEventResponse,
+  TeamListItemResponse,
 } from '@asap-hub/model';
 import { API_BASE_URL } from '../config';
+import { getAlgoliaTeams } from '../network/teams/api';
+
+const teamsForMatchingPageSize = 1000;
 
 export const getEvents = async (
   algoliaClient: AlgoliaClient<'crn'>,
@@ -86,4 +90,29 @@ export const patchEvent = async (
     );
   }
   return resp.json();
+};
+
+// One Algolia pass per upload instead of one query per uploaded name: the whole
+// corpus is resolved in memory by matchTeamNames.
+export const getTeamsForMatching = async (
+  algoliaClient: AlgoliaClient<'crn'>,
+): Promise<TeamListItemResponse[]> => {
+  const items: TeamListItemResponse[] = [];
+  let currentPage = 0;
+  let total = 0;
+
+  do {
+    // eslint-disable-next-line no-await-in-loop
+    const result = await getAlgoliaTeams(algoliaClient, {
+      searchQuery: '',
+      teamType: 'all',
+      currentPage,
+      pageSize: teamsForMatchingPageSize,
+    });
+    items.push(...result.items);
+    total = result.total;
+    currentPage += 1;
+  } while (items.length < total && items.length > 0);
+
+  return items;
 };

--- a/apps/crn-frontend/src/events/api.ts
+++ b/apps/crn-frontend/src/events/api.ts
@@ -13,7 +13,13 @@ import {
 import { API_BASE_URL } from '../config';
 import { getAlgoliaTeams } from '../network/teams/api';
 
-const teamsForMatchingPageSize = 1000;
+// Shared with the state hook so the cache key and the request cannot drift.
+export const teamsForMatchingOptions = {
+  searchQuery: '',
+  teamType: 'all',
+  currentPage: 0,
+  pageSize: 1000,
+} as const;
 
 export const getEvents = async (
   algoliaClient: AlgoliaClient<'crn'>,
@@ -103,12 +109,7 @@ export const getTeamsForMatching = async (
     // eslint-disable-next-line no-await-in-loop
     const { items: pageItems, total: pageTotal } = await getAlgoliaTeams(
       algoliaClient,
-      {
-        searchQuery: '',
-        teamType: 'all',
-        currentPage,
-        pageSize: teamsForMatchingPageSize,
-      },
+      { ...teamsForMatchingOptions, currentPage },
     );
     // An empty page guarantees termination even if total is off.
     if (pageItems.length === 0) {

--- a/apps/crn-frontend/src/events/match-team-names.ts
+++ b/apps/crn-frontend/src/events/match-team-names.ts
@@ -7,12 +7,14 @@ import {
 
 import { ParsedTeamRow } from './parse-team-list';
 
+const normalizeFull = (name: string): string =>
+  name.trim().replace(/\s+/g, ' ').toLowerCase();
+
+const stripTeamPrefix = (normalized: string): string =>
+  normalized.replace(/^team /, '');
+
 export const normalizeTeamName = (name: string): string =>
-  name
-    .trim()
-    .replace(/\s+/g, ' ')
-    .toLowerCase()
-    .replace(/^team /, '');
+  stripTeamPrefix(normalizeFull(name));
 
 const toAttendanceTeam = (
   team: TeamListItemResponse,
@@ -31,28 +33,47 @@ export const matchTeamNames = (
   rows: ParsedTeamRow[],
   teams: TeamListItemResponse[],
 ): UploadListResult => {
-  const teamsByName = new Map(
-    teams.map((team) => [normalizeTeamName(team.displayName), team]),
-  );
+  const byFullName = new Map<string, TeamListItemResponse>();
+  const strippedCounts = new Map<string, number>();
+  teams.forEach((team) => {
+    const stripped = normalizeTeamName(team.displayName);
+    byFullName.set(normalizeFull(team.displayName), team);
+    strippedCounts.set(stripped, (strippedCounts.get(stripped) ?? 0) + 1);
+  });
+  // Only resolve via the stripped ('Team X' -> 'X') form when it is unambiguous;
+  // otherwise a real team named 'Team X' would shadow a team named 'X'.
+  const byStrippedName = new Map<string, TeamListItemResponse>();
+  teams.forEach((team) => {
+    const stripped = normalizeTeamName(team.displayName);
+    if (strippedCounts.get(stripped) === 1) {
+      byStrippedName.set(stripped, team);
+    }
+  });
 
   const matched: EventAttendanceTeam[] = [];
   const unmatched: UploadListUnmatchedTeam[] = [];
-  const seen = new Set<string>();
+  const seenTeamIds = new Set<string>();
+  const seenUnmatched = new Set<string>();
 
   rows.forEach(({ name, attended }) => {
-    const normalized = normalizeTeamName(name);
-    if (!normalized || seen.has(normalized)) {
+    const full = normalizeFull(name);
+    if (!full) {
       return;
     }
-    seen.add(normalized);
 
-    const team = teamsByName.get(normalized);
+    const team = byFullName.get(full) ?? byStrippedName.get(stripTeamPrefix(full));
     if (!team) {
-      unmatched.push({ name: name.trim() });
+      if (!seenUnmatched.has(full)) {
+        seenUnmatched.add(full);
+        unmatched.push({ name: name.trim() });
+      }
       return;
     }
 
-    matched.push(toAttendanceTeam(team, attended));
+    if (!seenTeamIds.has(team.id)) {
+      seenTeamIds.add(team.id);
+      matched.push(toAttendanceTeam(team, attended));
+    }
   });
 
   return { matched, unmatched };

--- a/apps/crn-frontend/src/events/match-team-names.ts
+++ b/apps/crn-frontend/src/events/match-team-names.ts
@@ -61,7 +61,8 @@ export const matchTeamNames = (
       return;
     }
 
-    const team = byFullName.get(full) ?? byStrippedName.get(stripTeamPrefix(full));
+    const team =
+      byFullName.get(full) ?? byStrippedName.get(stripTeamPrefix(full));
     if (!team) {
       if (!seenUnmatched.has(full)) {
         seenUnmatched.add(full);

--- a/apps/crn-frontend/src/events/match-team-names.ts
+++ b/apps/crn-frontend/src/events/match-team-names.ts
@@ -25,18 +25,17 @@ const toAttendanceTeam = (
   isTeamInactive: !!team.inactiveSince,
 });
 
+// Resolves uploaded names to Hub Teams; the modal decides which are already on
+// the table (it owns the live rows, including unsaved additions).
 export const matchTeamNames = (
   rows: ParsedTeamRow[],
   teams: TeamListItemResponse[],
-  currentRows: EventAttendanceTeam[],
 ): UploadListResult => {
   const teamsByName = new Map(
     teams.map((team) => [normalizeTeamName(team.displayName), team]),
   );
-  const currentTeamIds = new Set(currentRows.map(({ teamId }) => teamId));
 
   const matched: EventAttendanceTeam[] = [];
-  const alreadyIn: EventAttendanceTeam[] = [];
   const unmatched: UploadListUnmatchedTeam[] = [];
   const seen = new Set<string>();
 
@@ -53,13 +52,8 @@ export const matchTeamNames = (
       return;
     }
 
-    const entry = toAttendanceTeam(team, attended);
-    if (currentTeamIds.has(team.id)) {
-      alreadyIn.push(entry);
-    } else {
-      matched.push(entry);
-    }
+    matched.push(toAttendanceTeam(team, attended));
   });
 
-  return { matched, alreadyIn, unmatched };
+  return { matched, unmatched };
 };

--- a/apps/crn-frontend/src/events/match-team-names.ts
+++ b/apps/crn-frontend/src/events/match-team-names.ts
@@ -1,0 +1,61 @@
+import { TeamListItemResponse } from '@asap-hub/model';
+import {
+  EventAttendanceTeam,
+  UploadListResult,
+  UploadListUnmatchedTeam,
+} from '@asap-hub/react-components';
+
+// The Hub renders Teams as `Team {displayName}` but stores the bare
+// displayName, so a list transcribed from the UI carries a prefix that is not
+// part of any stored name.
+export const normalizeTeamName = (name: string): string =>
+  name
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+    .replace(/^team /, '');
+
+const toAttendanceTeam = (team: TeamListItemResponse): EventAttendanceTeam => ({
+  teamId: team.id,
+  teamName: team.displayName,
+  attended: true,
+  teamType: team.teamType,
+  isTeamInactive: !!team.inactiveSince,
+});
+
+export const matchTeamNames = (
+  names: string[],
+  teams: TeamListItemResponse[],
+  currentRows: EventAttendanceTeam[],
+): UploadListResult => {
+  const teamsByName = new Map(
+    teams.map((team) => [normalizeTeamName(team.displayName), team]),
+  );
+  const currentTeamIds = new Set(currentRows.map(({ teamId }) => teamId));
+
+  const matched: EventAttendanceTeam[] = [];
+  const unmatched: UploadListUnmatchedTeam[] = [];
+  const seen = new Set<string>();
+  let alreadyInCount = 0;
+
+  names.forEach((name) => {
+    const normalized = normalizeTeamName(name);
+    if (!normalized || seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+
+    const team = teamsByName.get(normalized);
+    if (!team) {
+      unmatched.push({ name: name.trim() });
+    } else if (currentTeamIds.has(team.id)) {
+      // Counted, never listed: the modal's total is
+      // matched + alreadyInCount + unmatched, so the sets must stay disjoint.
+      alreadyInCount += 1;
+    } else {
+      matched.push(toAttendanceTeam(team));
+    }
+  });
+
+  return { matched, alreadyInCount, unmatched };
+};

--- a/apps/crn-frontend/src/events/match-team-names.ts
+++ b/apps/crn-frontend/src/events/match-team-names.ts
@@ -5,9 +5,8 @@ import {
   UploadListUnmatchedTeam,
 } from '@asap-hub/react-components';
 
-// The Hub renders Teams as `Team {displayName}` but stores the bare
-// displayName, so a list transcribed from the UI carries a prefix that is not
-// part of any stored name.
+import { ParsedTeamRow } from './parse-team-list';
+
 export const normalizeTeamName = (name: string): string =>
   name
     .trim()
@@ -15,16 +14,19 @@ export const normalizeTeamName = (name: string): string =>
     .toLowerCase()
     .replace(/^team /, '');
 
-const toAttendanceTeam = (team: TeamListItemResponse): EventAttendanceTeam => ({
+const toAttendanceTeam = (
+  team: TeamListItemResponse,
+  attended: boolean,
+): EventAttendanceTeam => ({
   teamId: team.id,
   teamName: team.displayName,
-  attended: true,
+  attended,
   teamType: team.teamType,
   isTeamInactive: !!team.inactiveSince,
 });
 
 export const matchTeamNames = (
-  names: string[],
+  rows: ParsedTeamRow[],
   teams: TeamListItemResponse[],
   currentRows: EventAttendanceTeam[],
 ): UploadListResult => {
@@ -34,11 +36,11 @@ export const matchTeamNames = (
   const currentTeamIds = new Set(currentRows.map(({ teamId }) => teamId));
 
   const matched: EventAttendanceTeam[] = [];
+  const alreadyIn: EventAttendanceTeam[] = [];
   const unmatched: UploadListUnmatchedTeam[] = [];
   const seen = new Set<string>();
-  let alreadyInCount = 0;
 
-  names.forEach((name) => {
+  rows.forEach(({ name, attended }) => {
     const normalized = normalizeTeamName(name);
     if (!normalized || seen.has(normalized)) {
       return;
@@ -48,14 +50,16 @@ export const matchTeamNames = (
     const team = teamsByName.get(normalized);
     if (!team) {
       unmatched.push({ name: name.trim() });
-    } else if (currentTeamIds.has(team.id)) {
-      // Counted, never listed: the modal's total is
-      // matched + alreadyInCount + unmatched, so the sets must stay disjoint.
-      alreadyInCount += 1;
+      return;
+    }
+
+    const entry = toAttendanceTeam(team, attended);
+    if (currentTeamIds.has(team.id)) {
+      alreadyIn.push(entry);
     } else {
-      matched.push(toAttendanceTeam(team));
+      matched.push(entry);
     }
   });
 
-  return { matched, alreadyInCount, unmatched };
+  return { matched, alreadyIn, unmatched };
 };

--- a/apps/crn-frontend/src/events/parse-team-list.ts
+++ b/apps/crn-frontend/src/events/parse-team-list.ts
@@ -1,11 +1,29 @@
 import * as XLSX from 'xlsx';
 
-const headerAliases = ['team', 'team name', 'teams'];
+export type ParsedTeamRow = { name: string; attended: boolean };
 
-const normalizeHeader = (value: unknown): string =>
+const teamHeaderAliases = ['team', 'team name', 'teams'];
+const attendanceHeaderAliases = [
+  'attendance',
+  'attended',
+  'status',
+  'present',
+];
+const attendedValues = new Set([
+  'yes',
+  'y',
+  'true',
+  '1',
+  'attended',
+  'present',
+]);
+
+const normalizeCell = (value: unknown): string =>
   typeof value === 'string'
     ? value.trim().replace(/\s+/g, ' ').toLowerCase()
-    : '';
+    : typeof value === 'number'
+      ? String(value)
+      : '';
 
 const toCellText = (value: unknown): string => {
   if (typeof value === 'string') {
@@ -14,21 +32,31 @@ const toCellText = (value: unknown): string => {
   return typeof value === 'number' ? String(value) : '';
 };
 
-// The Team column is found by header so an export from the Hub's analytics
-// pages (which emits "Team Name") uploads unedited. A file without a
-// recognised header is treated as a bare list, so its first row is data.
-const findTeamColumn = (
+// Blank or unrecognised status defaults to not attended.
+// SheetJS coerces TRUE/FALSE cells to real booleans, so handle those directly.
+const parseAttended = (value: unknown): boolean =>
+  typeof value === 'boolean'
+    ? value
+    : attendedValues.has(normalizeCell(value));
+
+const findColumns = (
   firstRow: unknown[] = [],
-): { column: number; skipFirstRow: boolean } => {
-  const column = firstRow.findIndex((cell) =>
-    headerAliases.includes(normalizeHeader(cell)),
+): { teamColumn: number; attendanceColumn: number; skipFirstRow: boolean } => {
+  const teamHeader = firstRow.findIndex((cell) =>
+    teamHeaderAliases.includes(normalizeCell(cell)),
   );
-  return column === -1
-    ? { column: 0, skipFirstRow: false }
-    : { column, skipFirstRow: true };
+  const attendanceColumn = firstRow.findIndex((cell) =>
+    attendanceHeaderAliases.includes(normalizeCell(cell)),
+  );
+  const hasHeader = teamHeader !== -1 || attendanceColumn !== -1;
+  return {
+    teamColumn: teamHeader === -1 ? 0 : teamHeader,
+    attendanceColumn,
+    skipFirstRow: hasHeader,
+  };
 };
 
-export const parseSheet = (data: ArrayBuffer | string): string[] => {
+export const parseSheet = (data: ArrayBuffer | string): ParsedTeamRow[] => {
   const workbook =
     typeof data === 'string'
       ? XLSX.read(data, { type: 'string' })
@@ -41,16 +69,18 @@ export const parseSheet = (data: ArrayBuffer | string): string[] => {
   }
 
   const rows = XLSX.utils.sheet_to_json<unknown[]>(sheet, { header: 1 });
-  const { column, skipFirstRow } = findTeamColumn(rows[0]);
+  const { teamColumn, attendanceColumn, skipFirstRow } = findColumns(rows[0]);
 
   return rows
     .slice(skipFirstRow ? 1 : 0)
-    .map((row) => toCellText(row[column]))
-    .filter(Boolean);
+    .map((row) => ({
+      name: toCellText(row[teamColumn]),
+      attended:
+        attendanceColumn === -1 ? false : parseAttended(row[attendanceColumn]),
+    }))
+    .filter((row) => row.name);
 };
 
-// FileReader rather than file.text()/arrayBuffer(): jsdom does not implement
-// the Blob methods, so those only work in the browser.
 const readFile = (file: File): Promise<ArrayBuffer | string> =>
   new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -64,7 +94,9 @@ const readFile = (file: File): Promise<ArrayBuffer | string> =>
     }
   });
 
-export const parseTeamNames = async (files: File[]): Promise<string[]> => {
+export const parseTeamRows = async (
+  files: File[],
+): Promise<ParsedTeamRow[]> => {
   const perFile = await Promise.all(
     files.map(async (file) => parseSheet(await readFile(file))),
   );

--- a/apps/crn-frontend/src/events/parse-team-list.ts
+++ b/apps/crn-frontend/src/events/parse-team-list.ts
@@ -1,0 +1,72 @@
+import * as XLSX from 'xlsx';
+
+const headerAliases = ['team', 'team name', 'teams'];
+
+const normalizeHeader = (value: unknown): string =>
+  typeof value === 'string'
+    ? value.trim().replace(/\s+/g, ' ').toLowerCase()
+    : '';
+
+const toCellText = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  return typeof value === 'number' ? String(value) : '';
+};
+
+// The Team column is found by header so an export from the Hub's analytics
+// pages (which emits "Team Name") uploads unedited. A file without a
+// recognised header is treated as a bare list, so its first row is data.
+const findTeamColumn = (
+  firstRow: unknown[] = [],
+): { column: number; skipFirstRow: boolean } => {
+  const column = firstRow.findIndex((cell) =>
+    headerAliases.includes(normalizeHeader(cell)),
+  );
+  return column === -1
+    ? { column: 0, skipFirstRow: false }
+    : { column, skipFirstRow: true };
+};
+
+export const parseSheet = (data: ArrayBuffer | string): string[] => {
+  const workbook =
+    typeof data === 'string'
+      ? XLSX.read(data, { type: 'string' })
+      : XLSX.read(data, { type: 'array' });
+
+  const [firstSheetName] = workbook.SheetNames;
+  const sheet = firstSheetName && workbook.Sheets[firstSheetName];
+  if (!sheet) {
+    return [];
+  }
+
+  const rows = XLSX.utils.sheet_to_json<unknown[]>(sheet, { header: 1 });
+  const { column, skipFirstRow } = findTeamColumn(rows[0]);
+
+  return rows
+    .slice(skipFirstRow ? 1 : 0)
+    .map((row) => toCellText(row[column]))
+    .filter(Boolean);
+};
+
+// FileReader rather than file.text()/arrayBuffer(): jsdom does not implement
+// the Blob methods, so those only work in the browser.
+const readFile = (file: File): Promise<ArrayBuffer | string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer | string);
+    reader.onerror = () =>
+      reject(reader.error ?? new Error(`Could not read ${file.name}`));
+    if (file.name.toLowerCase().endsWith('.csv')) {
+      reader.readAsText(file);
+    } else {
+      reader.readAsArrayBuffer(file);
+    }
+  });
+
+export const parseTeamNames = async (files: File[]): Promise<string[]> => {
+  const perFile = await Promise.all(
+    files.map(async (file) => parseSheet(await readFile(file))),
+  );
+  return perFile.flat();
+};

--- a/apps/crn-frontend/src/events/parse-team-list.ts
+++ b/apps/crn-frontend/src/events/parse-team-list.ts
@@ -3,12 +3,7 @@ import * as XLSX from 'xlsx';
 export type ParsedTeamRow = { name: string; attended: boolean };
 
 const teamHeaderAliases = ['team', 'team name', 'teams'];
-const attendanceHeaderAliases = [
-  'attendance',
-  'attended',
-  'status',
-  'present',
-];
+const attendanceHeaderAliases = ['attendance', 'attended', 'status', 'present'];
 const attendedValues = new Set([
   'yes',
   'y',
@@ -35,9 +30,7 @@ const toCellText = (value: unknown): string => {
 // Blank or unrecognised status defaults to not attended.
 // SheetJS coerces TRUE/FALSE cells to real booleans, so handle those directly.
 const parseAttended = (value: unknown): boolean =>
-  typeof value === 'boolean'
-    ? value
-    : attendedValues.has(normalizeCell(value));
+  typeof value === 'boolean' ? value : attendedValues.has(normalizeCell(value));
 
 const findColumns = (
   firstRow: unknown[] = [],
@@ -49,11 +42,11 @@ const findColumns = (
     attendanceHeaderAliases.includes(normalizeCell(cell)),
   );
   const hasHeader = teamHeader !== -1 || attendanceColumn !== -1;
-  return {
-    teamColumn: teamHeader === -1 ? 0 : teamHeader,
-    attendanceColumn,
-    skipFirstRow: hasHeader,
-  };
+  // With no team header, fall back to the first column that is not the status
+  // column, so a status-first sheet doesn't read the status as team names.
+  const teamColumn =
+    teamHeader !== -1 ? teamHeader : attendanceColumn === 0 ? 1 : 0;
+  return { teamColumn, attendanceColumn, skipFirstRow: hasHeader };
 };
 
 export const parseSheet = (data: ArrayBuffer | string): ParsedTeamRow[] => {

--- a/apps/crn-frontend/src/events/parse-team-list.ts
+++ b/apps/crn-frontend/src/events/parse-team-list.ts
@@ -27,26 +27,52 @@ const toCellText = (value: unknown): string => {
   return typeof value === 'number' ? String(value) : '';
 };
 
-// Blank or unrecognised status defaults to not attended.
 // SheetJS coerces TRUE/FALSE cells to real booleans, so handle those directly.
 const parseAttended = (value: unknown): boolean =>
   typeof value === 'boolean' ? value : attendedValues.has(normalizeCell(value));
 
+const statusValues = new Set([...attendedValues, 'no', 'n', 'false', '0']);
+
+// A headerless list still carries attendance when one of its columns holds
+// nothing but yes/no values. Column 0 holds the names, so only look past it,
+// and require every non-empty cell to parse: an email or project column fails
+// that and is left alone.
+const sniffAttendanceColumn = (rows: unknown[][]): number => {
+  const width = Math.max(...rows.map((row) => row.length), 0);
+
+  for (let column = 1; column < width; column += 1) {
+    const cells = rows
+      .map((row) => normalizeCell(row[column]))
+      .filter((cell) => cell !== '');
+    if (cells.length > 0 && cells.every((cell) => statusValues.has(cell))) {
+      return column;
+    }
+  }
+  return -1;
+};
+
 const findColumns = (
-  firstRow: unknown[] = [],
+  rows: unknown[][],
 ): { teamColumn: number; attendanceColumn: number; skipFirstRow: boolean } => {
+  const [firstRow = []] = rows;
   const teamHeader = firstRow.findIndex((cell) =>
     teamHeaderAliases.includes(normalizeCell(cell)),
   );
-  const attendanceColumn = firstRow.findIndex((cell) =>
+  const attendanceHeader = firstRow.findIndex((cell) =>
     attendanceHeaderAliases.includes(normalizeCell(cell)),
   );
-  const hasHeader = teamHeader !== -1 || attendanceColumn !== -1;
+  const hasHeader = teamHeader !== -1 || attendanceHeader !== -1;
   // With no team header, fall back to the first column that is not the status
   // column, so a status-first sheet doesn't read the status as team names.
   const teamColumn =
-    teamHeader !== -1 ? teamHeader : attendanceColumn === 0 ? 1 : 0;
-  return { teamColumn, attendanceColumn, skipFirstRow: hasHeader };
+    teamHeader !== -1 ? teamHeader : attendanceHeader === 0 ? 1 : 0;
+  return {
+    teamColumn,
+    attendanceColumn: hasHeader
+      ? attendanceHeader
+      : sniffAttendanceColumn(rows),
+    skipFirstRow: hasHeader,
+  };
 };
 
 export const parseSheet = (data: ArrayBuffer | string): ParsedTeamRow[] => {
@@ -62,7 +88,7 @@ export const parseSheet = (data: ArrayBuffer | string): ParsedTeamRow[] => {
   }
 
   const rows = XLSX.utils.sheet_to_json<unknown[]>(sheet, { header: 1 });
-  const { teamColumn, attendanceColumn, skipFirstRow } = findColumns(rows[0]);
+  const { teamColumn, attendanceColumn, skipFirstRow } = findColumns(rows);
 
   return rows
     .slice(skipFirstRow ? 1 : 0)

--- a/apps/crn-frontend/src/events/state.ts
+++ b/apps/crn-frontend/src/events/state.ts
@@ -22,7 +22,13 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import { useAuthorization } from '../auth/useAuthorization';
 import { useAlgolia } from '../hooks/algolia';
 import { teamQueryKeys } from '../network/teams/state';
-import { getEvent, getEvents, getTeamsForMatching, patchEvent } from './api';
+import {
+  getEvent,
+  getEvents,
+  getTeamsForMatching,
+  patchEvent,
+  teamsForMatchingOptions,
+} from './api';
 import { mapSpeakersToGroups } from './map-speakers-to-groups';
 
 export const eventQueryKeys = createQueryKeys<GetEventListOptions>('events');
@@ -97,13 +103,6 @@ export const useEvents = (
       }),
   }).data;
 };
-
-const teamsForMatchingOptions = {
-  searchQuery: '',
-  teamType: 'all',
-  currentPage: 0,
-  pageSize: 1000,
-} as const;
 
 // fetchQuery rather than a hook subscription: the corpus is only needed once a
 // file is actually uploaded, and it must not suspend inside the modal.

--- a/apps/crn-frontend/src/events/state.ts
+++ b/apps/crn-frontend/src/events/state.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { User } from '@asap-hub/auth';
 import {
   createQueryKeys,
@@ -21,7 +21,8 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 
 import { useAuthorization } from '../auth/useAuthorization';
 import { useAlgolia } from '../hooks/algolia';
-import { getEvent, getEvents, patchEvent } from './api';
+import { teamQueryKeys } from '../network/teams/state';
+import { getEvent, getEvents, getTeamsForMatching, patchEvent } from './api';
 import { mapSpeakersToGroups } from './map-speakers-to-groups';
 
 export const eventQueryKeys = createQueryKeys<GetEventListOptions>('events');
@@ -95,4 +96,28 @@ export const useEvents = (
         items: [],
       }),
   }).data;
+};
+
+const teamsForMatchingOptions = {
+  searchQuery: '',
+  teamType: 'all',
+  currentPage: 0,
+  pageSize: 1000,
+} as const;
+
+// fetchQuery rather than a hook subscription: the corpus is only needed once a
+// file is actually uploaded, and it must not suspend inside the modal.
+export const useTeamsForMatching = () => {
+  const { client } = useAlgolia();
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    () =>
+      queryClient.fetchQuery({
+        queryKey: teamQueryKeys.list(teamsForMatchingOptions),
+        queryFn: () => getTeamsForMatching(client),
+        staleTime: Infinity,
+      }),
+    [client, queryClient],
+  );
 };

--- a/apps/storybook/src/EditEventAttendanceModal.stories.tsx
+++ b/apps/storybook/src/EditEventAttendanceModal.stories.tsx
@@ -117,7 +117,7 @@ const commonArgs = {
   // demonstrated in the Attendance > Edit and Save story, not here.
   onUploadList: async () => ({
     matched: [],
-    alreadyInCount: 0,
+    alreadyIn: [],
     unmatched: [],
   }),
   onSave: () => undefined,

--- a/apps/storybook/src/EditEventAttendanceModal.stories.tsx
+++ b/apps/storybook/src/EditEventAttendanceModal.stories.tsx
@@ -117,7 +117,6 @@ const commonArgs = {
   // demonstrated in the Attendance > Edit and Save story, not here.
   onUploadList: async () => ({
     matched: [],
-    alreadyIn: [],
     unmatched: [],
   }),
   onSave: () => undefined,

--- a/apps/storybook/src/EventAttendance.stories.tsx
+++ b/apps/storybook/src/EventAttendance.stories.tsx
@@ -212,7 +212,7 @@ export const EditAndSave: Story = {
                   teamType: 'Discovery Team',
                 },
               ],
-              alreadyInCount: 0,
+              alreadyIn: [],
               unmatched: [{ name: 'Data Scince' }],
             })}
             onSave={(updated) => {

--- a/apps/storybook/src/EventAttendance.stories.tsx
+++ b/apps/storybook/src/EventAttendance.stories.tsx
@@ -212,7 +212,6 @@ export const EditAndSave: Story = {
                   teamType: 'Discovery Team',
                 },
               ],
-              alreadyIn: [],
               unmatched: [{ name: 'Data Scince' }],
             })}
             onSave={(updated) => {

--- a/apps/storybook/src/UploadListModal.stories.tsx
+++ b/apps/storybook/src/UploadListModal.stories.tsx
@@ -47,7 +47,10 @@ const fullResult: UploadListResult = {
       teamType: 'Discovery Team',
     },
   ],
-  alreadyInCount: 2,
+  alreadyIn: [
+    { teamId: 'a1', teamName: 'Genetics', attended: true },
+    { teamId: 'a2', teamName: 'Proteomics', attended: false },
+  ],
   unmatched: [
     {
       name: 'Imagimg',
@@ -96,7 +99,7 @@ export const NoMatches: Story = {
     initialFiles: seedFiles,
     initialResult: {
       matched: [],
-      alreadyInCount: 0,
+      alreadyIn: [],
       unmatched: fullResult.unmatched,
     },
     initialSectionsOpen: true,

--- a/apps/storybook/src/UploadListModal.stories.tsx
+++ b/apps/storybook/src/UploadListModal.stories.tsx
@@ -47,10 +47,6 @@ const fullResult: UploadListResult = {
       teamType: 'Discovery Team',
     },
   ],
-  alreadyIn: [
-    { teamId: 'a1', teamName: 'Genetics', attended: true },
-    { teamId: 'a2', teamName: 'Proteomics', attended: false },
-  ],
   unmatched: [
     {
       name: 'Imagimg',
@@ -99,7 +95,6 @@ export const NoMatches: Story = {
     initialFiles: seedFiles,
     initialResult: {
       matched: [],
-      alreadyIn: [],
       unmatched: fullResult.unmatched,
     },
     initialSectionsOpen: true,

--- a/packages/react-components/src/atoms/Anchor.tsx
+++ b/packages/react-components/src/atoms/Anchor.tsx
@@ -19,28 +19,33 @@ type AnchorProps = {
   // hrefs may conditionally be undefined, but the prop is mandatory so it cannot be forgotten
   href: string | undefined;
   enabled?: boolean;
+  // Opts an internal link out of same-tab routing, for places where navigating
+  // away would discard unsaved work.
+  openInNewTab?: boolean;
 } & Omit<LinkProps, 'to'> &
   Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'target' | 'rel'>;
 const Anchor: React.FC<AnchorProps> = ({
   href,
   enabled = true,
   onClick,
+  openInNewTab = false,
   ...props
 }) => {
   const blockedClick = useBlockedClick(onClick);
   const [internal, url] =
     enabled && href ? isInternalLink(href) : [false, undefined];
-  if (useHasRouter() && url && internal) {
+  if (useHasRouter() && url && internal && !openInNewTab) {
     return (
       <Link {...props} to={url} css={resetStyles} onClick={blockedClick} />
     );
   }
+  const newTab = openInNewTab || !internal;
   return (
     <a
       {...props}
       href={(enabled && href) || undefined}
-      target={internal ? undefined : '_blank'}
-      rel={internal ? undefined : 'noreferrer noopener'}
+      target={newTab ? '_blank' : undefined}
+      rel={newTab ? 'noreferrer noopener' : undefined}
       css={resetStyles}
       onClick={onClick}
     />

--- a/packages/react-components/src/atoms/Link.tsx
+++ b/packages/react-components/src/atoms/Link.tsx
@@ -90,6 +90,7 @@ type LinkProps = {
   readonly ellipsed?: boolean;
   readonly underlined?: boolean;
   readonly onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+  readonly openInNewTab?: boolean;
 } & (NormalLinkProps | ButtonStyleLinkProps);
 
 const Link: React.FC<LinkProps> = ({
@@ -107,6 +108,7 @@ const Link: React.FC<LinkProps> = ({
   fullWidth = false,
   ellipsed = false,
   underlined = false,
+  openInNewTab = false,
 }) => {
   const linkStyles = ({ colors }: Theme) =>
     buttonStyle
@@ -133,6 +135,7 @@ const Link: React.FC<LinkProps> = ({
     <Anchor
       href={href}
       enabled={enabled}
+      openInNewTab={openInNewTab}
       aria-label={label}
       onClick={onClick}
       css={(theme) => linkStyles(theme)}

--- a/packages/react-components/src/atoms/RailTooltip.tsx
+++ b/packages/react-components/src/atoms/RailTooltip.tsx
@@ -11,6 +11,7 @@ import {
 
 import { paper, space } from '../colors';
 import { rem } from '../pixels';
+import { canHover } from '../utils/common';
 import { Portal } from '../utils/portal';
 
 const wrapperStyles = css({
@@ -50,12 +51,6 @@ const bubbleStyles = css({
 });
 
 type Coords = { left: number; top: number };
-
-// Touch taps fire an emulated mouseenter right before the click, which would
-// flash the tooltip on mobile; only hover-capable pointers should show it.
-const canHover = () =>
-  typeof window.matchMedia !== 'function' ||
-  window.matchMedia('(hover: hover)').matches;
 
 type RailTooltipProps = {
   readonly label: ReactNode;

--- a/packages/react-components/src/atoms/Tooltip.tsx
+++ b/packages/react-components/src/atoms/Tooltip.tsx
@@ -70,6 +70,9 @@ interface TooltipProps {
   bottom?: string;
   textStyles?: SerializedStyles;
   width?: string | number;
+  // Recolours the bubble and its tail together; the tail is drawn by a
+  // pseudo-element that no style prop can reach from the outside.
+  background?: string;
 }
 const Tooltip: React.FC<TooltipProps> = ({
   children,
@@ -78,6 +81,7 @@ const Tooltip: React.FC<TooltipProps> = ({
   bottom,
   textStyles,
   width,
+  background,
 }) => {
   const widthValue =
     width !== undefined
@@ -92,6 +96,7 @@ const Tooltip: React.FC<TooltipProps> = ({
         css={[
           tooltipStyles,
           { width: widthValue },
+          background ? { '::before': { borderTopColor: background } } : {},
           shown || { display: 'none' },
           maxContent && { width: 'max-content' },
           bottom && { bottom },
@@ -102,6 +107,7 @@ const Tooltip: React.FC<TooltipProps> = ({
           css={[
             bubbleStyles,
             { maxWidth: widthValue },
+            background ? { backgroundColor: background } : {},
             maxContent && { width: 'max-content', maxWidth: 'fit-content' },
             textStyles,
           ]}

--- a/packages/react-components/src/atoms/__tests__/Anchor.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/Anchor.test.tsx
@@ -126,3 +126,26 @@ describe('for an internal link with a router', () => {
     expect(fireEvent.click(anchor)).toBe(false);
   });
 });
+
+describe('openInNewTab', () => {
+  it('opens an internal link in a new tab instead of routing', () => {
+    const { getByRole } = render(
+      <Anchor href="/teams/42" openInNewTab>
+        text
+      </Anchor>,
+      { wrapper: MemoryRouterWithFuture },
+    );
+
+    const anchor = getByRole('link');
+    expect(anchor).toHaveAttribute('target', '_blank');
+    expect(anchor).toHaveAttribute('rel', 'noreferrer noopener');
+  });
+
+  it('keeps an internal link in the same tab by default', () => {
+    const { getByRole } = render(<Anchor href="/teams/42">text</Anchor>, {
+      wrapper: MemoryRouterWithFuture,
+    });
+
+    expect(getByRole('link')).not.toHaveAttribute('target');
+  });
+});

--- a/packages/react-components/src/atoms/__tests__/Link.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/Link.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
 import { findParentWithStyle } from '@asap-hub/dom-test-utils';
 import { ThemeProvider } from '@emotion/react';
 
@@ -276,4 +277,15 @@ it('forwards the click handler to the anchor', () => {
 
   getByText('text').click();
   expect(handleClick).toHaveBeenCalled();
+});
+
+it('passes openInNewTab through to the anchor', () => {
+  const { getByRole } = render(
+    <Link href="/teams/42" openInNewTab>
+      text
+    </Link>,
+    { wrapper: MemoryRouter },
+  );
+
+  expect(getByRole('link')).toHaveAttribute('target', '_blank');
 });

--- a/packages/react-components/src/atoms/__tests__/Tooltip.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/Tooltip.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import { rem } from '../../pixels';
+import { space } from '../../colors';
 
 import Tooltip from '../Tooltip';
 
@@ -24,4 +25,25 @@ it('applies width as rem when width is a number', () => {
   expect(getByRole('tooltip').parentElement).toHaveStyle({
     width: rem(width),
   });
+});
+
+it('recolours the bubble and its tail when a background is given', () => {
+  const { getByRole } = render(
+    <Tooltip shown background="rgb(0, 32, 44)">
+      text
+    </Tooltip>,
+  );
+
+  const bubble = getByRole('tooltip');
+  expect(bubble).toHaveStyle({ backgroundColor: 'rgb(0, 32, 44)' });
+  expect(bubble.parentElement).toHaveStyleRule(
+    'border-top-color',
+    'rgb(0, 32, 44)',
+    { target: '::before' },
+  );
+});
+
+it('keeps the default background when none is given', () => {
+  const { getByRole } = render(<Tooltip shown>text</Tooltip>);
+  expect(getByRole('tooltip')).toHaveStyle({ backgroundColor: space.rgb });
 });

--- a/packages/react-components/src/molecules/Info.tsx
+++ b/packages/react-components/src/molecules/Info.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 
 import { Tooltip } from '../atoms';
 import { infoIcon } from '../icons';
+import { canHover } from '../utils/common';
 
 const buttonStyles = css({
   padding: 0,
@@ -17,8 +18,16 @@ interface InfoProps {
   children: ReactNode;
   width?: string | number;
   background?: string;
+  // Also opens on hover, the way the navigation rail tooltip does. Click stays
+  // the primary trigger, so touch devices keep working.
+  openOnHover?: boolean;
 }
-const Info: React.FC<InfoProps> = ({ children, width, background }) => {
+const Info: React.FC<InfoProps> = ({
+  children,
+  width,
+  background,
+  openOnHover = false,
+}) => {
   const [tooltipShown, setTooltipShown] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -48,7 +57,16 @@ const Info: React.FC<InfoProps> = ({ children, width, background }) => {
     <button
       ref={buttonRef}
       css={buttonStyles}
-      onClick={() => setTooltipShown((shown) => !shown)}
+      // With hover on, the pointer already opened the tooltip by the time the
+      // click lands, so toggling would close it mid-gesture; hovering out,
+      // Escape and an outside click are what dismiss it.
+      onClick={() => setTooltipShown((shown) => openOnHover || !shown)}
+      onMouseEnter={
+        openOnHover ? () => canHover() && setTooltipShown(true) : undefined
+      }
+      onMouseLeave={openOnHover ? () => setTooltipShown(false) : undefined}
+      onFocus={openOnHover ? () => setTooltipShown(true) : undefined}
+      onBlur={openOnHover ? () => setTooltipShown(false) : undefined}
     >
       <Tooltip shown={tooltipShown} width={width} background={background}>
         {children}

--- a/packages/react-components/src/molecules/Info.tsx
+++ b/packages/react-components/src/molecules/Info.tsx
@@ -15,8 +15,10 @@ const buttonStyles = css({
 
 interface InfoProps {
   children: ReactNode;
+  width?: string | number;
+  background?: string;
 }
-const Info: React.FC<InfoProps> = ({ children }) => {
+const Info: React.FC<InfoProps> = ({ children, width, background }) => {
   const [tooltipShown, setTooltipShown] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -48,7 +50,9 @@ const Info: React.FC<InfoProps> = ({ children }) => {
       css={buttonStyles}
       onClick={() => setTooltipShown((shown) => !shown)}
     >
-      <Tooltip shown={tooltipShown}>{children}</Tooltip>
+      <Tooltip shown={tooltipShown} width={width} background={background}>
+        {children}
+      </Tooltip>
       <span>{infoIcon}</span>
     </button>
   );

--- a/packages/react-components/src/molecules/Info.tsx
+++ b/packages/react-components/src/molecules/Info.tsx
@@ -1,9 +1,17 @@
-import { ReactNode, useEffect, useRef, useState } from 'react';
+import {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { css } from '@emotion/react';
 
 import { Tooltip } from '../atoms';
 import { infoIcon } from '../icons';
 import { canHover } from '../utils/common';
+import { Portal } from '../utils/portal';
 
 const buttonStyles = css({
   padding: 0,
@@ -14,6 +22,17 @@ const buttonStyles = css({
   cursor: 'pointer',
 });
 
+// A zero-sized anchor pinned over the icon. The bubble is absolute inside it,
+// so it lands above the icon exactly as it does inline, but outside any
+// scrollable ancestor: an absolutely positioned bubble widens its scroll
+// container, and the resulting scrollbar shifts the icon out from under the
+// pointer, which closes and reopens the tooltip in a loop.
+const floatingAnchorStyles = css({
+  position: 'fixed',
+  zIndex: 100,
+  pointerEvents: 'none',
+});
+
 interface InfoProps {
   children: ReactNode;
   width?: string | number;
@@ -21,15 +40,44 @@ interface InfoProps {
   // Also opens on hover, the way the navigation rail tooltip does. Click stays
   // the primary trigger, so touch devices keep working.
   openOnHover?: boolean;
+  // Renders the bubble in a portal, for tooltips inside a scrollable area.
+  floating?: boolean;
 }
 const Info: React.FC<InfoProps> = ({
   children,
   width,
   background,
   openOnHover = false,
+  floating = false,
 }) => {
   const [tooltipShown, setTooltipShown] = useState(false);
+  const [anchor, setAnchor] = useState<{ left: number; top: number } | null>(
+    null,
+  );
   const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const measureAnchor = useCallback(() => {
+    const rect = buttonRef.current?.getBoundingClientRect();
+    if (rect) {
+      setAnchor({ left: rect.left + rect.width / 2, top: rect.top });
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!floating || !tooltipShown) {
+      setAnchor(null);
+      return undefined;
+    }
+
+    measureAnchor();
+    // Capture phase, so scrolling any ancestor keeps the bubble on the icon.
+    window.addEventListener('scroll', measureAnchor, true);
+    window.addEventListener('resize', measureAnchor);
+    return () => {
+      window.removeEventListener('scroll', measureAnchor, true);
+      window.removeEventListener('resize', measureAnchor);
+    };
+  }, [floating, tooltipShown, measureAnchor]);
 
   useEffect(() => {
     if (!tooltipShown) return undefined;
@@ -53,6 +101,12 @@ const Info: React.FC<InfoProps> = ({
     };
   }, [tooltipShown]);
 
+  const tooltip = (
+    <Tooltip shown={tooltipShown} width={width} background={background}>
+      {children}
+    </Tooltip>
+  );
+
   return (
     <button
       ref={buttonRef}
@@ -68,9 +122,15 @@ const Info: React.FC<InfoProps> = ({
       onFocus={openOnHover ? () => setTooltipShown(true) : undefined}
       onBlur={openOnHover ? () => setTooltipShown(false) : undefined}
     >
-      <Tooltip shown={tooltipShown} width={width} background={background}>
-        {children}
-      </Tooltip>
+      {floating
+        ? anchor && (
+            <Portal>
+              <span css={floatingAnchorStyles} style={anchor}>
+                {tooltip}
+              </span>
+            </Portal>
+          )
+        : tooltip}
       <span>{infoIcon}</span>
     </button>
   );

--- a/packages/react-components/src/molecules/TooltipInfo.tsx
+++ b/packages/react-components/src/molecules/TooltipInfo.tsx
@@ -23,6 +23,7 @@ type TooltipInfoProps = {
   width?: string | number;
   background?: string;
   openOnHover?: boolean;
+  floating?: boolean;
 };
 
 const TooltipInfo: React.FC<TooltipInfoProps> = ({
@@ -32,12 +33,18 @@ const TooltipInfo: React.FC<TooltipInfoProps> = ({
   width,
   background,
   openOnHover,
+  floating,
 }) => (
   <span
     css={[infoWrapperStyle, overrideWrapperStyles]}
     onClick={(e) => e.preventDefault()}
   >
-    <Info width={width} background={background} openOnHover={openOnHover}>
+    <Info
+      width={width}
+      background={background}
+      openOnHover={openOnHover}
+      floating={floating}
+    >
       <span css={[infoStyle, overrideTooltipStyles]}>{children}</span>
     </Info>
   </span>

--- a/packages/react-components/src/molecules/TooltipInfo.tsx
+++ b/packages/react-components/src/molecules/TooltipInfo.tsx
@@ -20,18 +20,22 @@ type TooltipInfoProps = {
   overrideWrapperStyles?: SerializedStyles;
   overrideTooltipStyles?: SerializedStyles;
   children: React.ReactNode;
+  width?: string | number;
+  background?: string;
 };
 
 const TooltipInfo: React.FC<TooltipInfoProps> = ({
   overrideWrapperStyles,
   overrideTooltipStyles,
   children,
+  width,
+  background,
 }) => (
   <span
     css={[infoWrapperStyle, overrideWrapperStyles]}
     onClick={(e) => e.preventDefault()}
   >
-    <Info>
+    <Info width={width} background={background}>
       <span css={[infoStyle, overrideTooltipStyles]}>{children}</span>
     </Info>
   </span>

--- a/packages/react-components/src/molecules/TooltipInfo.tsx
+++ b/packages/react-components/src/molecules/TooltipInfo.tsx
@@ -22,6 +22,7 @@ type TooltipInfoProps = {
   children: React.ReactNode;
   width?: string | number;
   background?: string;
+  openOnHover?: boolean;
 };
 
 const TooltipInfo: React.FC<TooltipInfoProps> = ({
@@ -30,12 +31,13 @@ const TooltipInfo: React.FC<TooltipInfoProps> = ({
   children,
   width,
   background,
+  openOnHover,
 }) => (
   <span
     css={[infoWrapperStyle, overrideWrapperStyles]}
     onClick={(e) => e.preventDefault()}
   >
-    <Info width={width} background={background}>
+    <Info width={width} background={background} openOnHover={openOnHover}>
       <span css={[infoStyle, overrideTooltipStyles]}>{children}</span>
     </Info>
   </span>

--- a/packages/react-components/src/molecules/__tests__/TooltipInfo.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/TooltipInfo.test.tsx
@@ -1,12 +1,76 @@
 import { render, screen, fireEvent, createEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import TooltipInfo from '../TooltipInfo';
+
+const realMatchMedia = window.matchMedia;
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: realMatchMedia,
+  });
+});
 
 describe('TooltipInfo', () => {
   it('renders info text', () => {
     render(<TooltipInfo>Test Content</TooltipInfo>);
 
     expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('opens on hover and closes again when openOnHover is set', async () => {
+    render(<TooltipInfo openOnHover>Test Content</TooltipInfo>);
+    const infoButton = screen.getByRole('button', { name: /info/i });
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+    await userEvent.hover(infoButton);
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Test Content');
+
+    await userEvent.unhover(infoButton);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('ignores hover by default', async () => {
+    render(<TooltipInfo>Test Content</TooltipInfo>);
+
+    await userEvent.hover(screen.getByRole('button', { name: /info/i }));
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('stays open when the hovered icon is clicked', async () => {
+    render(<TooltipInfo openOnHover>Test Content</TooltipInfo>);
+
+    await userEvent.click(screen.getByRole('button', { name: /info/i }));
+
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Test Content');
+  });
+
+  it('opens on keyboard focus and closes on blur', async () => {
+    render(<TooltipInfo openOnHover>Test Content</TooltipInfo>);
+
+    await userEvent.tab();
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Test Content');
+
+    await userEvent.tab();
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('ignores hover on a device that cannot hover', async () => {
+    const matchMedia = jest.fn().mockReturnValue({ matches: false });
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: matchMedia,
+    });
+    render(<TooltipInfo openOnHover>Test Content</TooltipInfo>);
+
+    await userEvent.hover(screen.getByRole('button', { name: /info/i }));
+
+    expect(matchMedia).toHaveBeenCalledWith('(hover: hover)');
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
 
   it('calls preventDefault when user clicks on the button', () => {

--- a/packages/react-components/src/molecules/__tests__/TooltipInfo.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/TooltipInfo.test.tsx
@@ -73,6 +73,43 @@ describe('TooltipInfo', () => {
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
 
+  it('renders the bubble outside the button when floating', async () => {
+    const { container } = render(
+      <TooltipInfo openOnHover floating>
+        Test Content
+      </TooltipInfo>,
+    );
+
+    await userEvent.hover(screen.getByRole('button', { name: /info/i }));
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Test Content');
+    expect(container).not.toContainElement(tooltip);
+  });
+
+  it('keeps the floating bubble on the icon while an ancestor scrolls', async () => {
+    jest
+      .spyOn(HTMLButtonElement.prototype, 'getBoundingClientRect')
+      .mockReturnValueOnce({ left: 100, top: 200, width: 24 } as DOMRect)
+      .mockReturnValueOnce({ left: 100, top: 150, width: 24 } as DOMRect);
+
+    render(
+      <TooltipInfo openOnHover floating>
+        Test Content
+      </TooltipInfo>,
+    );
+    await userEvent.hover(screen.getByRole('button', { name: /info/i }));
+
+    const anchorOf = () =>
+      screen.getByRole('tooltip').closest('span[style]') as HTMLElement;
+    expect(anchorOf()).toHaveStyle({ left: '112px', top: '200px' });
+
+    fireEvent.scroll(window);
+
+    expect(anchorOf()).toHaveStyle({ left: '112px', top: '150px' });
+    jest.restoreAllMocks();
+  });
+
   it('calls preventDefault when user clicks on the button', () => {
     render(<TooltipInfo>Test Content</TooltipInfo>);
 

--- a/packages/react-components/src/organisms/EditEventAttendanceModal.tsx
+++ b/packages/react-components/src/organisms/EditEventAttendanceModal.tsx
@@ -443,10 +443,9 @@ const EditEventAttendanceModal: React.FC<EditEventAttendanceModalProps> = ({
       return [...current, ...additions];
     });
 
-  // Upload upserts: a Team already on the table keeps its row (and its
-  // server-side attendanceId) but takes the uploaded attendance status; a new
-  // Team is appended. Kept separate from addTeams so the search and
-  // interest-group paths stay append-only and never overwrite a toggle.
+  // Upsert kept separate from addTeams so the search and interest-group paths
+  // stay append-only: an existing row keeps its attendanceId and takes the
+  // uploaded status; a new team is appended.
   const applyUploadedTeams = (teamsToApply: EventAttendanceTeam[]) => {
     setRows((current) => {
       const byId = new Map(current.map((team) => [team.teamId, team]));

--- a/packages/react-components/src/organisms/EditEventAttendanceModal.tsx
+++ b/packages/react-components/src/organisms/EditEventAttendanceModal.tsx
@@ -35,7 +35,7 @@ import {
 } from '../icons';
 import { ConfirmableModalFooter, Modal } from '../molecules';
 import { mobileScreen, rem } from '../pixels';
-import { noop } from '../utils';
+import { noop, pluralizeTeams } from '../utils';
 import { EventAttendanceTeam } from './EventAttendance';
 import { teamIcon } from './shared-event-card';
 import {
@@ -727,7 +727,7 @@ const EditEventAttendanceModal: React.FC<EditEventAttendanceModalProps> = ({
                         <span css={searchOptionMetaStyles}>
                           {allAdded
                             ? '• all teams already added'
-                            : `• adds ${option.teams.length} teams`}
+                            : `• adds ${pluralizeTeams(option.teams.length)}`}
                         </span>
                       )}
                     </span>

--- a/packages/react-components/src/organisms/EditEventAttendanceModal.tsx
+++ b/packages/react-components/src/organisms/EditEventAttendanceModal.tsx
@@ -25,6 +25,7 @@ import {
 } from '../colors';
 import {
   binIcon,
+  InactiveBadgeIcon,
   crossIcon,
   InterestGroupsIcon,
   plusIcon,
@@ -821,6 +822,7 @@ const EditEventAttendanceModal: React.FC<EditEventAttendanceModalProps> = ({
                       >
                         {team.teamName}
                       </Link>
+                      {team.isTeamInactive && <InactiveBadgeIcon />}
                     </span>
                     <span css={attendanceCellStyles}>
                       <span css={attendanceSwitchStyles}>

--- a/packages/react-components/src/organisms/EditEventAttendanceModal.tsx
+++ b/packages/react-components/src/organisms/EditEventAttendanceModal.tsx
@@ -443,6 +443,25 @@ const EditEventAttendanceModal: React.FC<EditEventAttendanceModalProps> = ({
       return [...current, ...additions];
     });
 
+  // Upload upserts: a Team already on the table keeps its row (and its
+  // server-side attendanceId) but takes the uploaded attendance status; a new
+  // Team is appended. Kept separate from addTeams so the search and
+  // interest-group paths stay append-only and never overwrite a toggle.
+  const applyUploadedTeams = (teamsToApply: EventAttendanceTeam[]) => {
+    setRows((current) => {
+      const byId = new Map(current.map((team) => [team.teamId, team]));
+      teamsToApply.forEach((team) =>
+        byId.set(team.teamId, { ...byId.get(team.teamId), ...team }),
+      );
+      return [...byId.values()];
+    });
+    setManualTeamIds((prev) => {
+      const next = new Set(prev);
+      teamsToApply.forEach((team) => next.add(team.teamId));
+      return next;
+    });
+  };
+
   const addManualTeams = (teamsToAdd: EventAttendanceTeam[]) => {
     addTeams(teamsToAdd);
     setManualTeamIds((prev) => {
@@ -469,7 +488,7 @@ const EditEventAttendanceModal: React.FC<EditEventAttendanceModalProps> = ({
     uploadedTeams: EventAttendanceTeam[],
     files: File[],
   ) => {
-    addManualTeams(uploadedTeams);
+    applyUploadedTeams(uploadedTeams);
     const addedDate = new Date().toLocaleDateString('en-GB');
     setSourceFiles((current) => [
       ...current,

--- a/packages/react-components/src/organisms/EditEventAttendanceModal.tsx
+++ b/packages/react-components/src/organisms/EditEventAttendanceModal.tsx
@@ -607,6 +607,7 @@ const EditEventAttendanceModal: React.FC<EditEventAttendanceModalProps> = ({
         onUploadList={onUploadList}
         onAddAttendees={handleUploadAddAttendees}
         onBack={() => setShowUploadList(false)}
+        currentTeamIds={new Set(rows.map((team) => team.teamId))}
       />
     );
   }

--- a/packages/react-components/src/organisms/EventAttendance.tsx
+++ b/packages/react-components/src/organisms/EventAttendance.tsx
@@ -15,6 +15,7 @@ import {
 } from '../icons';
 import { EventAttendanceMetric } from '../molecules';
 import { rem } from '../pixels';
+import { pluralizeTeams } from '../utils/events';
 
 import { defaultVisibleTeams, teamIcon } from './shared-event-card';
 import {
@@ -202,7 +203,7 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
             variant="progress"
             label="This event"
             value={attendancePercentage}
-            caption={`${teamsAttended} of ${teamsTotal} teams`}
+            caption={`${teamsAttended} of ${pluralizeTeams(teamsTotal)}`}
           />
           {!sinceLastEvent ? (
             <EventAttendanceMetric
@@ -216,7 +217,9 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
               direction="none"
               label="Since last event"
               value={0}
-              caption={`No change from ${sinceLastEvent.teamsAttended} of ${sinceLastEvent.teamsTotal} teams`}
+              caption={`No change from ${
+                sinceLastEvent.teamsAttended
+              } of ${pluralizeTeams(sinceLastEvent.teamsTotal)}`}
             />
           ) : (
             <EventAttendanceMetric
@@ -224,7 +227,9 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
               direction={sinceLastEvent.count < 0 ? 'down' : 'up'}
               label="Since last event"
               value={Math.abs(sinceLastEvent.count)}
-              caption={`from ${sinceLastEvent.teamsAttended} of ${sinceLastEvent.teamsTotal} teams`}
+              caption={`from ${
+                sinceLastEvent.teamsAttended
+              } of ${pluralizeTeams(sinceLastEvent.teamsTotal)}`}
             />
           )}
         </div>

--- a/packages/react-components/src/organisms/EventSpeakers.tsx
+++ b/packages/react-components/src/organisms/EventSpeakers.tsx
@@ -32,6 +32,7 @@ import {
 } from '../molecules/shared-metric-card-styles';
 import SpeakerUserRow from '../molecules/SpeakerUserRow';
 import { rem, tabletScreen } from '../pixels';
+import { pluralizeTeams } from '../utils';
 
 import { defaultVisibleTeams, teamIcon } from './shared-event-card';
 import {
@@ -379,7 +380,7 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
             <FindingsMetric
               label="Preliminary findings"
               value={findingsPercentage}
-              caption={`${teamsShared} of ${teamsTotal} teams`}
+              caption={`${teamsShared} of ${pluralizeTeams(teamsTotal)}`}
             />
           )}
         </div>

--- a/packages/react-components/src/organisms/UploadListModal.tsx
+++ b/packages/react-components/src/organisms/UploadListModal.tsx
@@ -47,7 +47,9 @@ export type UploadListUnmatchedTeam = {
 
 export type UploadListResult = {
   matched: EventAttendanceTeam[];
-  alreadyInCount: number;
+  // Teams from the file already on the attendance table: not re-added, but
+  // their attendance status is updated in place.
+  alreadyIn: EventAttendanceTeam[];
   unmatched: UploadListUnmatchedTeam[];
 };
 
@@ -478,12 +480,14 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
     ? result.unmatched.filter((team) => !isPromoted(team))
     : [];
 
+  const alreadyIn = result?.alreadyIn ?? [];
   const totalTeams = result
-    ? result.matched.length + result.alreadyInCount + result.unmatched.length
+    ? result.matched.length + alreadyIn.length + result.unmatched.length
     : 0;
 
-  // "Already in" Teams are only ever a count, so a list whose names are all
-  // already on the attendance table leaves both sections empty.
+  // "Already in" Teams are not listed as additions, so a file whose names are
+  // all already on the attendance table leaves both sections empty; their
+  // status is still updated on save.
   const hasSections = matchedTeams.length > 0 || remainingUnmatched.length > 0;
   const emptyResultMessage =
     totalTeams === 0
@@ -491,7 +495,8 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
       : `All ${totalTeams} Teams in this list are already in the attendance table.`;
 
   const isDirty = files.length > 0 || matchedTeams.length > 0;
-  const addEnabled = matchedTeams.length > 0 && !isSaving;
+  const addEnabled =
+    (matchedTeams.length > 0 || alreadyIn.length > 0) && !isSaving;
 
   const requestClose = () => {
     if (isDirty) {
@@ -504,7 +509,7 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
   const handleAddAttendees = async () => {
     setIsSaving(true);
     try {
-      await onAddAttendees(matchedTeams, files);
+      await onAddAttendees([...matchedTeams, ...alreadyIn], files);
     } catch {
       // The caller surfaces the error; the modal only needs to unlock so the
       // user can retry or cancel instead of staying stuck on "saving".
@@ -607,7 +612,7 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
               <span css={summarySeparatorStyles}>•</span>
               <span>{result.matched.length} matched</span>
               <span css={summarySeparatorStyles}>•</span>
-              <span>{result.alreadyInCount} already in</span>
+              <span>{alreadyIn.length} already in</span>
             </div>
 
             {!hasSections && (

--- a/packages/react-components/src/organisms/UploadListModal.tsx
+++ b/packages/react-components/src/organisms/UploadListModal.tsx
@@ -16,6 +16,7 @@ import {
 import {
   binIcon,
   chevronDownIcon,
+  InactiveBadgeIcon,
   crossIcon,
   crossSmallIcon,
   chevronLeftIcon,
@@ -24,6 +25,7 @@ import {
 } from '../icons';
 import { ConfirmableModalFooter, Modal } from '../molecules';
 import { rem } from '../pixels';
+import { pluralizeTeams } from '../utils/events';
 import {
   EventAttendanceTeam,
   EventAttendanceTeamType,
@@ -497,11 +499,25 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
     ? result.matched.length + result.unmatched.length
     : 0;
 
+  // A file that yields no names is reported as an upload error rather than as
+  // an empty result, so the counts line never reads "0 Teams".
+  const yieldedNothing = !!result && totalTeams === 0;
+  // A file or selection problem is the more specific cause, so it wins.
+  const shownError =
+    error ??
+    (yieldedNothing
+      ? 'No team names found. Check that the file has a Team Name column.'
+      : null);
+
   const hasSections = matchedTeams.length > 0 || remainingUnmatched.length > 0;
+  // Describes the file, not the current view: once the user deletes the rows
+  // themselves there is nothing to explain, so no message is shown.
   const emptyResultMessage =
-    totalTeams === 0
-      ? 'No Team names found. Check that the file has a Team column.'
-      : `All ${totalTeams} Teams in this list are already in the attendance table.`;
+    newMatchedCount === 0
+      ? `All ${pluralizeTeams(alreadyIn.length)} in this list ${
+          alreadyIn.length === 1 ? 'is' : 'are'
+        } already in the attendance table.`
+      : null;
 
   const isDirty = files.length > 0 || matchedTeams.length > 0;
   const addEnabled =
@@ -608,24 +624,26 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
             {!isUploading && plusIcon}
             Add
           </Button>
-          {error && (
+          {shownError && (
             <p css={errorStyles} role="alert">
-              {error}
+              {shownError}
             </p>
           )}
         </section>
 
-        {result && (
+        {result && !yieldedNothing && (
           <div css={resultStyles}>
             <div css={summaryStyles}>
-              <span css={summaryStrongStyles}>{totalTeams} Teams</span>
+              <span css={summaryStrongStyles}>
+                {pluralizeTeams(totalTeams, true)}
+              </span>
               <span css={summarySeparatorStyles}>•</span>
               <span>{newMatchedCount} matched</span>
               <span css={summarySeparatorStyles}>•</span>
               <span>{alreadyIn.length} already in</span>
             </div>
 
-            {!hasSections && (
+            {!hasSections && emptyResultMessage && (
               <p css={emptyResultStyles}>{emptyResultMessage}</p>
             )}
 
@@ -644,8 +662,8 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
                       >
                         {tickSmallIcon}
                         <span>
-                          <strong>{matchedTeams.length} teams</strong> will be
-                          added and marked if attended
+                          <strong>{pluralizeTeams(matchedTeams.length)}</strong>{' '}
+                          will be added and marked if attended
                         </span>
                       </span>
                       <span css={chevronStyles(matchedOpen)}>
@@ -659,6 +677,7 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
                             <span css={matchedTeamStyles}>
                               {teamIcon(team.teamType)}
                               <Link
+                                openInNewTab
                                 href={
                                   network({})
                                     .teams({})
@@ -669,6 +688,7 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
                                   {team.teamName}
                                 </span>
                               </Link>
+                              {team.isTeamInactive && <InactiveBadgeIcon />}
                             </span>
                             <Button
                               noMargin

--- a/packages/react-components/src/organisms/UploadListModal.tsx
+++ b/packages/react-components/src/organisms/UploadListModal.tsx
@@ -46,10 +46,7 @@ export type UploadListUnmatchedTeam = {
 };
 
 export type UploadListResult = {
-  // Every uploaded name resolved to a Hub Team, with its uploaded status. The
-  // modal splits these against the current table into new additions and
-  // "already in" (updated in place), so resolution stays independent of table
-  // state.
+  // Every resolved Hub Team, new or already on the table; the modal splits them.
   matched: EventAttendanceTeam[];
   unmatched: UploadListUnmatchedTeam[];
 };
@@ -68,9 +65,8 @@ type UploadListModalProps = {
     files: File[],
   ) => void | Promise<void>;
   onBack: () => void;
-  // Team ids currently on the attendance table (including unsaved additions).
-  // Resolved teams already present are shown as "already in" and updated in
-  // place rather than listed as new additions.
+  // Team ids already on the table (including unsaved additions), shown as
+  // "already in" rather than new.
   currentTeamIds?: ReadonlySet<string>;
   maxFileSizeMb?: number;
   accept?: string;
@@ -475,15 +471,10 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
   ): team is UploadListUnmatchedTeam & { suggestion: UploadListSuggestion } =>
     !!team.suggestion && addedSuggestionIds.has(team.suggestion.teamId);
 
-  // A resolved team already on the attendance table is "already in": not listed
-  // as a new addition, updated in place on save. Split against the live table
-  // (which includes unsaved additions), not the server state.
   const alreadyIn = result
     ? result.matched.filter((team) => currentTeamIds.has(team.teamId))
     : [];
-  const newMatchedCount = result
-    ? result.matched.length - alreadyIn.length
-    : 0;
+  const newMatchedCount = result ? result.matched.length - alreadyIn.length : 0;
 
   const matchedTeams: EventAttendanceTeam[] = result
     ? [
@@ -506,9 +497,6 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
     ? result.matched.length + result.unmatched.length
     : 0;
 
-  // "Already in" Teams are not listed as additions, so a file whose names are
-  // all already on the attendance table leaves both sections empty; their
-  // status is still updated on save.
   const hasSections = matchedTeams.length > 0 || remainingUnmatched.length > 0;
   const emptyResultMessage =
     totalTeams === 0

--- a/packages/react-components/src/organisms/UploadListModal.tsx
+++ b/packages/react-components/src/organisms/UploadListModal.tsx
@@ -46,10 +46,11 @@ export type UploadListUnmatchedTeam = {
 };
 
 export type UploadListResult = {
+  // Every uploaded name resolved to a Hub Team, with its uploaded status. The
+  // modal splits these against the current table into new additions and
+  // "already in" (updated in place), so resolution stays independent of table
+  // state.
   matched: EventAttendanceTeam[];
-  // Teams from the file already on the attendance table: not re-added, but
-  // their attendance status is updated in place.
-  alreadyIn: EventAttendanceTeam[];
   unmatched: UploadListUnmatchedTeam[];
 };
 
@@ -67,6 +68,10 @@ type UploadListModalProps = {
     files: File[],
   ) => void | Promise<void>;
   onBack: () => void;
+  // Team ids currently on the attendance table (including unsaved additions).
+  // Resolved teams already present are shown as "already in" and updated in
+  // place rather than listed as new additions.
+  currentTeamIds?: ReadonlySet<string>;
   maxFileSizeMb?: number;
   accept?: string;
   initialFiles?: File[];
@@ -364,10 +369,13 @@ const suggestionToTeam = (
   teamType: suggestion.teamType,
 });
 
+const noTeamIds: ReadonlySet<string> = new Set();
+
 const UploadListModal: React.FC<UploadListModalProps> = ({
   onUploadList,
   onAddAttendees,
   onBack,
+  currentTeamIds = noTeamIds,
   maxFileSizeMb = defaultMaxFileSizeMb,
   accept = defaultAccept,
   initialFiles = [],
@@ -467,9 +475,23 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
   ): team is UploadListUnmatchedTeam & { suggestion: UploadListSuggestion } =>
     !!team.suggestion && addedSuggestionIds.has(team.suggestion.teamId);
 
+  // A resolved team already on the attendance table is "already in": not listed
+  // as a new addition, updated in place on save. Split against the live table
+  // (which includes unsaved additions), not the server state.
+  const alreadyIn = result
+    ? result.matched.filter((team) => currentTeamIds.has(team.teamId))
+    : [];
+  const newMatchedCount = result
+    ? result.matched.length - alreadyIn.length
+    : 0;
+
   const matchedTeams: EventAttendanceTeam[] = result
     ? [
-        ...result.matched.filter((team) => !removedMatchedIds.has(team.teamId)),
+        ...result.matched.filter(
+          (team) =>
+            !currentTeamIds.has(team.teamId) &&
+            !removedMatchedIds.has(team.teamId),
+        ),
         ...result.unmatched
           .filter(isPromoted)
           .map((team) => suggestionToTeam(team.suggestion)),
@@ -480,9 +502,8 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
     ? result.unmatched.filter((team) => !isPromoted(team))
     : [];
 
-  const alreadyIn = result?.alreadyIn ?? [];
   const totalTeams = result
-    ? result.matched.length + alreadyIn.length + result.unmatched.length
+    ? result.matched.length + result.unmatched.length
     : 0;
 
   // "Already in" Teams are not listed as additions, so a file whose names are
@@ -610,7 +631,7 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
             <div css={summaryStyles}>
               <span css={summaryStrongStyles}>{totalTeams} Teams</span>
               <span css={summarySeparatorStyles}>•</span>
-              <span>{result.matched.length} matched</span>
+              <span>{newMatchedCount} matched</span>
               <span css={summarySeparatorStyles}>•</span>
               <span>{alreadyIn.length} already in</span>
             </div>

--- a/packages/react-components/src/organisms/UploadListModal.tsx
+++ b/packages/react-components/src/organisms/UploadListModal.tsx
@@ -323,6 +323,14 @@ const addSuggestionButtonStyles = css({
   ...buttonIconGapReset,
 });
 
+const emptyResultStyles = css({
+  margin: 0,
+  color: lead.rgb,
+  fontSize: rem(17),
+  fontWeight: 400,
+  lineHeight: rem(24),
+});
+
 const unmatchedHelpStyles = css({
   margin: 0,
   color: lead.rgb,
@@ -384,7 +392,13 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
   const allowedExtensions = getAllowedExtensions(accept);
   const maxBytes = maxFileSizeMb * 1000 * 1000;
 
-  const runUpload = (nextFiles: File[]) => {
+  // selectionError is whatever the file selection itself decided (size or
+  // extension). It is restored on success so a successful parse clears only a
+  // previous read failure, not the warning about the files that were skipped.
+  const runUpload = (
+    nextFiles: File[],
+    selectionError: string | null = null,
+  ) => {
     setFiles(nextFiles);
     // A new file set invalidates the per-team edits made against the old result.
     setAddedSuggestionIds(new Set());
@@ -402,12 +416,14 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
       .then((uploadResult) => {
         if (seq === uploadSeq.current) {
           setResult(uploadResult);
+          setError(selectionError);
           setIsUploading(false);
         }
       })
       .catch(() => {
         if (seq === uploadSeq.current) {
           setResult(null);
+          setError('Something went wrong reading this file. Please try again.');
           setIsUploading(false);
         }
       });
@@ -422,18 +438,16 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
       (file) =>
         hasAllowedExtension(file, allowedExtensions) && file.size > maxBytes,
     );
+    let selectionError: string | null = null;
     if (tooLarge) {
-      setError(
-        `The file size exceeds the limit of ${maxFileSizeMb} MB. Please upload a smaller file.`,
-      );
+      selectionError = `The file size exceeds the limit of ${maxFileSizeMb} MB. Please upload a smaller file.`;
     } else if (valid.length < selected.length) {
-      setError('CSV or XLSX files only.');
-    } else {
-      setError(null);
+      selectionError = 'CSV or XLSX files only.';
     }
+    setError(selectionError);
     if (valid.length > 0) {
       setIsUploading(true);
-      runUpload([...files, ...valid]);
+      runUpload([...files, ...valid], selectionError);
     }
   };
 
@@ -467,6 +481,14 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
   const totalTeams = result
     ? result.matched.length + result.alreadyInCount + result.unmatched.length
     : 0;
+
+  // "Already in" Teams are only ever a count, so a list whose names are all
+  // already on the attendance table leaves both sections empty.
+  const hasSections = matchedTeams.length > 0 || remainingUnmatched.length > 0;
+  const emptyResultMessage =
+    totalTeams === 0
+      ? 'No Team names found. Check that the file has a Team column.'
+      : `All ${totalTeams} Teams in this list are already in the attendance table.`;
 
   const isDirty = files.length > 0 || matchedTeams.length > 0;
   const addEnabled = matchedTeams.length > 0 && !isSaving;
@@ -588,143 +610,153 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
               <span>{result.alreadyInCount} already in</span>
             </div>
 
-            <div css={resultCardStyles(!isCancelling)}>
-              {matchedTeams.length > 0 && (
-                <>
-                  <button
-                    type="button"
-                    css={sectionHeaderStyles}
-                    aria-expanded={matchedOpen}
-                    onClick={() => setMatchedOpen((open) => !open)}
-                  >
-                    <span css={[sectionHeaderLabelStyles, matchedLabelStyles]}>
-                      {tickSmallIcon}
-                      <span>
-                        <strong>{matchedTeams.length} teams</strong> will be
-                        added and marked if attended
-                      </span>
-                    </span>
-                    <span css={chevronStyles(matchedOpen)}>
-                      {chevronDownIcon}
-                    </span>
-                  </button>
-                  {matchedOpen && (
-                    <div css={sectionBodyStyles}>
-                      {matchedTeams.map((team) => (
-                        <div key={team.teamId} css={matchedRowStyles}>
-                          <span css={matchedTeamStyles}>
-                            {teamIcon(team.teamType)}
-                            <Link
-                              href={
-                                network({})
-                                  .teams({})
-                                  .team({ teamId: team.teamId }).$
-                              }
-                            >
-                              <span css={matchedTeamNameStyles}>
-                                {team.teamName}
-                              </span>
-                            </Link>
-                          </span>
-                          <Button
-                            noMargin
-                            enabled={!isCancelling}
-                            aria-label={`Remove ${team.teamName}`}
-                            onClick={() => removeMatchedTeam(team.teamId)}
-                            overrideStyles={deleteButtonStyles(!isCancelling)}
-                          >
-                            {binIcon}
-                          </Button>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </>
-              )}
+            {!hasSections && (
+              <p css={emptyResultStyles}>{emptyResultMessage}</p>
+            )}
 
-              {matchedTeams.length > 0 && remainingUnmatched.length > 0 && (
-                <div css={dividerStyles} />
-              )}
-
-              {remainingUnmatched.length > 0 && (
-                <>
-                  <button
-                    type="button"
-                    css={sectionHeaderStyles}
-                    aria-expanded={unmatchedOpen}
-                    onClick={() => setUnmatchedOpen((open) => !open)}
-                  >
-                    <span
-                      css={[sectionHeaderLabelStyles, notMatchedLabelStyles]}
+            {hasSections && (
+              <div css={resultCardStyles(!isCancelling)}>
+                {matchedTeams.length > 0 && (
+                  <>
+                    <button
+                      type="button"
+                      css={sectionHeaderStyles}
+                      aria-expanded={matchedOpen}
+                      onClick={() => setMatchedOpen((open) => !open)}
                     >
-                      {crossSmallIcon}
-                      <span>
-                        <strong>{remainingUnmatched.length} not matched</strong>{' '}
-                        • will not be added
+                      <span
+                        css={[sectionHeaderLabelStyles, matchedLabelStyles]}
+                      >
+                        {tickSmallIcon}
+                        <span>
+                          <strong>{matchedTeams.length} teams</strong> will be
+                          added and marked if attended
+                        </span>
                       </span>
-                    </span>
-                    <span css={chevronStyles(unmatchedOpen)}>
-                      {chevronDownIcon}
-                    </span>
-                  </button>
-                  {unmatchedOpen && (
-                    <div css={sectionBodyStyles}>
-                      <div css={unmatchedRowsStyles}>
-                        {remainingUnmatched.map((team) => {
-                          const { suggestion } = team;
-                          return (
-                            <div key={team.name} css={unmatchedRowStyles}>
-                              <span css={unmatchedTextStyles}>
-                                “{team.name}”{' '}
-                                {suggestion ? (
-                                  <span css={unmatchedMetaStyles}>
-                                    • did you mean{' '}
-                                    <Link
-                                      href={
-                                        network({}).teams({}).team({
-                                          teamId: suggestion.teamId,
-                                        }).$
-                                      }
-                                    >
-                                      <span css={suggestionLinkStyles}>
-                                        {suggestion.teamName}
-                                      </span>
-                                    </Link>
-                                    ?
-                                  </span>
-                                ) : (
-                                  <span css={unmatchedMetaStyles}>
-                                    • no close match
-                                  </span>
-                                )}
-                              </span>
-                              {suggestion && (
-                                <Button
-                                  small
-                                  noMargin
-                                  enabled={!isCancelling}
-                                  overrideStyles={addSuggestionButtonStyles}
-                                  onClick={() =>
-                                    promoteSuggestion(suggestion.teamId)
-                                  }
-                                >
-                                  {plusIcon}
-                                  Add
-                                </Button>
-                              )}
-                            </div>
-                          );
-                        })}
+                      <span css={chevronStyles(matchedOpen)}>
+                        {chevronDownIcon}
+                      </span>
+                    </button>
+                    {matchedOpen && (
+                      <div css={sectionBodyStyles}>
+                        {matchedTeams.map((team) => (
+                          <div key={team.teamId} css={matchedRowStyles}>
+                            <span css={matchedTeamStyles}>
+                              {teamIcon(team.teamType)}
+                              <Link
+                                href={
+                                  network({})
+                                    .teams({})
+                                    .team({ teamId: team.teamId }).$
+                                }
+                              >
+                                <span css={matchedTeamNameStyles}>
+                                  {team.teamName}
+                                </span>
+                              </Link>
+                            </span>
+                            <Button
+                              noMargin
+                              enabled={!isCancelling}
+                              aria-label={`Remove ${team.teamName}`}
+                              onClick={() => removeMatchedTeam(team.teamId)}
+                              overrideStyles={deleteButtonStyles(!isCancelling)}
+                            >
+                              {binIcon}
+                            </Button>
+                          </div>
+                        ))}
                       </div>
-                      <p css={unmatchedHelpStyles}>
-                        Add a suggested team to include it, or fix the name in
-                        your file and upload again.
-                      </p>
-                    </div>
-                  )}
-                </>
-              )}
-            </div>
+                    )}
+                  </>
+                )}
+
+                {matchedTeams.length > 0 && remainingUnmatched.length > 0 && (
+                  <div css={dividerStyles} />
+                )}
+
+                {remainingUnmatched.length > 0 && (
+                  <>
+                    <button
+                      type="button"
+                      css={sectionHeaderStyles}
+                      aria-expanded={unmatchedOpen}
+                      onClick={() => setUnmatchedOpen((open) => !open)}
+                    >
+                      <span
+                        css={[sectionHeaderLabelStyles, notMatchedLabelStyles]}
+                      >
+                        {crossSmallIcon}
+                        <span>
+                          <strong>
+                            {remainingUnmatched.length} not matched
+                          </strong>{' '}
+                          • will not be added
+                        </span>
+                      </span>
+                      <span css={chevronStyles(unmatchedOpen)}>
+                        {chevronDownIcon}
+                      </span>
+                    </button>
+                    {unmatchedOpen && (
+                      <div css={sectionBodyStyles}>
+                        <div css={unmatchedRowsStyles}>
+                          {remainingUnmatched.map((team) => {
+                            const { suggestion } = team;
+                            return (
+                              <div key={team.name} css={unmatchedRowStyles}>
+                                <span css={unmatchedTextStyles}>
+                                  “{team.name}”{' '}
+                                  {suggestion ? (
+                                    <span css={unmatchedMetaStyles}>
+                                      • did you mean{' '}
+                                      <Link
+                                        href={
+                                          network({}).teams({}).team({
+                                            teamId: suggestion.teamId,
+                                          }).$
+                                        }
+                                      >
+                                        <span css={suggestionLinkStyles}>
+                                          {suggestion.teamName}
+                                        </span>
+                                      </Link>
+                                      ?
+                                    </span>
+                                  ) : (
+                                    <span css={unmatchedMetaStyles}>
+                                      • no close match
+                                    </span>
+                                  )}
+                                </span>
+                                {suggestion && (
+                                  <Button
+                                    small
+                                    noMargin
+                                    enabled={!isCancelling}
+                                    overrideStyles={addSuggestionButtonStyles}
+                                    onClick={() =>
+                                      promoteSuggestion(suggestion.teamId)
+                                    }
+                                  >
+                                    {plusIcon}
+                                    Add
+                                  </Button>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                        <p css={unmatchedHelpStyles}>
+                          Add a suggested team to include it, or fix the name in
+                          your file and upload again.
+                        </p>
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/packages/react-components/src/organisms/UploadListModal.tsx
+++ b/packages/react-components/src/organisms/UploadListModal.tsx
@@ -575,9 +575,9 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
 
       <div css={bodyStyles}>
         <Paragraph noMargin accent="lead">
-          Add teams from a list, each with the attendance marked in the file.
-          Teams already on the list keep their place and take the file&apos;s
-          attendance. CSV or XLSX files only.
+          Add teams from a list. Matched teams are added and marked attended. If
+          a team is already in your list, their attendance will be updated to
+          match the file. CSV or XLSX files only.
         </Paragraph>
 
         <section css={uploadSectionStyles}>

--- a/packages/react-components/src/organisms/UploadListModal.tsx
+++ b/packages/react-components/src/organisms/UploadListModal.tsx
@@ -559,8 +559,9 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
 
       <div css={bodyStyles}>
         <Paragraph noMargin accent="lead">
-          Add teams from a list. Matched teams are added and marked attended.
-          Teams already added are skipped. CSV or XLSX files only.
+          Add teams from a list, each with the attendance marked in the file.
+          Teams already on the list keep their place and take the file&apos;s
+          attendance. CSV or XLSX files only.
         </Paragraph>
 
         <section css={uploadSectionStyles}>

--- a/packages/react-components/src/organisms/UploadListModal.tsx
+++ b/packages/react-components/src/organisms/UploadListModal.tsx
@@ -591,6 +591,7 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
           a team is already in your list, their attendance will be updated to
           match the file. CSV or XLSX files only.
           <TooltipInfo
+            openOnHover
             width={296}
             background={neutral1000.rgb}
             overrideTooltipStyles={formatTooltipStyles}

--- a/packages/react-components/src/organisms/UploadListModal.tsx
+++ b/packages/react-components/src/organisms/UploadListModal.tsx
@@ -592,6 +592,7 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
           match the file. CSV or XLSX files only.
           <TooltipInfo
             openOnHover
+            floating
             width={296}
             background={neutral1000.rgb}
             overrideTooltipStyles={formatTooltipStyles}

--- a/packages/react-components/src/organisms/UploadListModal.tsx
+++ b/packages/react-components/src/organisms/UploadListModal.tsx
@@ -524,12 +524,13 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
   const hasSections = matchedTeams.length > 0 || remainingUnmatched.length > 0;
   // Describes the file, not the current view: once the user deletes the rows
   // themselves there is nothing to explain, so no message is shown.
-  const emptyResultMessage =
-    newMatchedCount === 0
-      ? `All ${pluralizeTeams(alreadyIn.length)} in this list ${
-          alreadyIn.length === 1 ? 'is' : 'are'
-        } already in the attendance table.`
-      : null;
+  const alreadyInMessage =
+    alreadyIn.length === 1
+      ? 'This team is already in the attendance table.'
+      : `All ${pluralizeTeams(
+          alreadyIn.length,
+        )} in this list are already in the attendance table.`;
+  const emptyResultMessage = newMatchedCount === 0 ? alreadyInMessage : null;
 
   const isDirty = files.length > 0 || matchedTeams.length > 0;
   const addEnabled =

--- a/packages/react-components/src/organisms/UploadListModal.tsx
+++ b/packages/react-components/src/organisms/UploadListModal.tsx
@@ -23,7 +23,7 @@ import {
   plusIcon,
   tickSmallIcon,
 } from '../icons';
-import { ConfirmableModalFooter, Modal } from '../molecules';
+import { ConfirmableModalFooter, Modal, TooltipInfo } from '../molecules';
 import { rem } from '../pixels';
 import { pluralizeTeams } from '../utils/events';
 import {
@@ -336,6 +336,18 @@ const emptyResultStyles = css({
   lineHeight: rem(24),
 });
 
+// Caption/C1 from the designs: four lines at 16px with nothing between them,
+// so the shared 6px row gap is dropped here.
+const formatTooltipStyles = css({
+  gap: 0,
+  paddingTop: 0,
+  paddingBottom: 0,
+  textAlign: 'left',
+  fontSize: rem(14),
+  fontWeight: 400,
+  lineHeight: rem(16),
+});
+
 const unmatchedHelpStyles = css({
   margin: 0,
   color: lead.rgb,
@@ -578,6 +590,16 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
           Add teams from a list. Matched teams are added and marked attended. If
           a team is already in your list, their attendance will be updated to
           match the file. CSV or XLSX files only.
+          <TooltipInfo
+            width={296}
+            background={neutral1000.rgb}
+            overrideTooltipStyles={formatTooltipStyles}
+          >
+            <span>Your file needs two columns.</span>
+            <span>For team names, use the header Team.</span>
+            <span>For attendance, use Attended.</span>
+            <span>Mark attendance as yes/no.</span>
+          </TooltipInfo>
         </Paragraph>
 
         <section css={uploadSectionStyles}>

--- a/packages/react-components/src/organisms/__tests__/EditEventAttendanceModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/EditEventAttendanceModal.test.tsx
@@ -64,7 +64,7 @@ const onUploadList = jest.fn(async () => ({
   matched: [
     { teamId: 'uploaded-1', teamName: 'Uploaded Team', attended: true },
   ],
-  alreadyInCount: 0,
+  alreadyIn: [],
   unmatched: [],
 }));
 
@@ -476,6 +476,36 @@ describe('EditEventAttendanceModal', () => {
     expect(screen.getByText('Source lists')).toBeInTheDocument();
     expect(screen.getByText('• 1 File')).toBeInTheDocument();
     expect(screen.getByText('teams.csv')).toBeInTheDocument();
+  });
+
+  it('Should update an already-listed team from an upload without duplicating it', async () => {
+    const uploadUpdate = jest.fn(async () => ({
+      matched: [],
+      alreadyIn: [{ teamId: 't1', teamName: 'Team Alpha', attended: false }],
+      unmatched: [],
+    }));
+    const { container } = renderModal({ teams, onUploadList: uploadUpdate });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /Upload a List/ }),
+    );
+    await userEvent.upload(
+      container.querySelector('input[type="file"]') as HTMLInputElement,
+      new File(['team'], 'teams.csv', { type: 'text/csv' }),
+    );
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Add Attendees' }),
+    );
+
+    // No duplicate row is added: the two seeded teams remain.
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSave).toHaveBeenCalledWith([
+      expect.objectContaining({ teamId: 't1', attended: false }),
+      expect.objectContaining({ teamId: 't2', attended: false }),
+    ]);
   });
 
   it('Should pluralise the source list count for multiple files', () => {

--- a/packages/react-components/src/organisms/__tests__/EditEventAttendanceModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/EditEventAttendanceModal.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
 import { StaticRouter } from 'react-router';
@@ -106,6 +106,25 @@ describe('EditEventAttendanceModal', () => {
     expect(
       screen.queryByRole('button', { name: 'Mark All Attended' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('Should flag an inactive team in the attendees table', () => {
+    renderModal({
+      teams: [
+        { ...teams[0]!, isTeamInactive: true },
+        { ...teams[1]!, isTeamInactive: false },
+      ],
+    });
+
+    const inactiveRow = screen
+      .getByRole('link', { name: 'Team Alpha' })
+      .closest('span') as HTMLElement;
+    const activeRow = screen
+      .getByRole('link', { name: 'Team Beta' })
+      .closest('span') as HTMLElement;
+
+    expect(within(inactiveRow).getByTitle('Inactive Team')).toBeInTheDocument();
+    expect(within(activeRow).queryByTitle('Inactive Team')).toBeNull();
   });
 
   it('Should render the "Edit Attendance" title, rows and counts when attendees exist', () => {

--- a/packages/react-components/src/organisms/__tests__/EditEventAttendanceModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/EditEventAttendanceModal.test.tsx
@@ -64,7 +64,6 @@ const onUploadList = jest.fn(async () => ({
   matched: [
     { teamId: 'uploaded-1', teamName: 'Uploaded Team', attended: true },
   ],
-  alreadyIn: [],
   unmatched: [],
 }));
 
@@ -479,9 +478,10 @@ describe('EditEventAttendanceModal', () => {
   });
 
   it('Should update an already-listed team from an upload without duplicating it', async () => {
+    // t1 is already among `teams`, so the modal classifies it as already-in and
+    // updates the row in place rather than adding a duplicate.
     const uploadUpdate = jest.fn(async () => ({
-      matched: [],
-      alreadyIn: [{ teamId: 't1', teamName: 'Team Alpha', attended: false }],
+      matched: [{ teamId: 't1', teamName: 'Team Alpha', attended: false }],
       unmatched: [],
     }));
     const { container } = renderModal({ teams, onUploadList: uploadUpdate });

--- a/packages/react-components/src/organisms/__tests__/UploadListModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/UploadListModal.test.tsx
@@ -13,6 +13,7 @@ import { silver } from '../../colors';
 
 import UploadListModal, { UploadListResult } from '../UploadListModal';
 
+// m1 is new; a1/a2 are resolved teams already on the table (see currentIds).
 const uploadResult: UploadListResult = {
   matched: [
     {
@@ -21,8 +22,6 @@ const uploadResult: UploadListResult = {
       attended: true,
       teamType: 'Discovery Team',
     },
-  ],
-  alreadyIn: [
     { teamId: 'a1', teamName: 'Genetics', attended: true },
     { teamId: 'a2', teamName: 'Proteomics', attended: false },
   ],
@@ -38,6 +37,8 @@ const uploadResult: UploadListResult = {
     { name: 'Data Scince' },
   ],
 };
+
+const currentIds = new Set(['a1', 'a2']);
 
 const onUploadList = jest.fn(async () => uploadResult);
 const onAddAttendees = jest.fn();
@@ -56,6 +57,7 @@ const renderModal = (
         onUploadList={onUploadList}
         onAddAttendees={onAddAttendees}
         onBack={onBack}
+        currentTeamIds={currentIds}
         {...overrides}
       />
     </StaticRouter>,
@@ -322,9 +324,9 @@ describe('UploadListModal', () => {
 
   it('Should explain an empty card when every team is already in', async () => {
     const { container } = renderModal({
+      currentTeamIds: new Set(['a1', 'a2', 'a3']),
       onUploadList: jest.fn(async () => ({
-        matched: [],
-        alreadyIn: [
+        matched: [
           { teamId: 'a1', teamName: 'A', attended: true },
           { teamId: 'a2', teamName: 'B', attended: false },
           { teamId: 'a3', teamName: 'C', attended: true },
@@ -347,7 +349,6 @@ describe('UploadListModal', () => {
     const { container } = renderModal({
       onUploadList: jest.fn(async () => ({
         matched: [],
-        alreadyIn: [],
         unmatched: [],
       })),
     });
@@ -442,7 +443,6 @@ describe('UploadListModal', () => {
     const { container } = renderModal({
       onUploadList: jest.fn(async () => ({
         matched: uploadResult.matched,
-        alreadyIn: [],
         unmatched: [],
       })),
     });
@@ -461,7 +461,6 @@ describe('UploadListModal', () => {
     const { container } = renderModal({
       onUploadList: jest.fn(async () => ({
         matched: [],
-        alreadyIn: [],
         unmatched: uploadResult.unmatched,
       })),
     });
@@ -495,8 +494,7 @@ describe('UploadListModal', () => {
   it('Should let the user apply status updates when every team is already in', async () => {
     const { container } = renderModal({
       onUploadList: jest.fn(async () => ({
-        matched: [],
-        alreadyIn: [{ teamId: 'a1', teamName: 'Genetics', attended: false }],
+        matched: [{ teamId: 'a1', teamName: 'Genetics', attended: false }],
         unmatched: [],
       })),
     });

--- a/packages/react-components/src/organisms/__tests__/UploadListModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/UploadListModal.test.tsx
@@ -99,7 +99,7 @@ describe('UploadListModal', () => {
     expect(screen.getByText('5 Teams')).toBeInTheDocument();
     expect(screen.getByText('1 matched')).toBeInTheDocument();
     expect(screen.getByText('2 already in')).toBeInTheDocument();
-    expect(screen.getByText('1 teams')).toBeInTheDocument();
+    expect(screen.getByText('1 team')).toBeInTheDocument();
     expect(screen.getByText('2 not matched')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Add Attendees' })).toBeEnabled();
   });
@@ -284,16 +284,7 @@ describe('UploadListModal', () => {
       ).toBeDisabled(),
     );
     expect(screen.queryByText('5 Teams')).not.toBeInTheDocument();
-  });
-
-  it('Should show a read error when the upload parse fails', async () => {
-    const { container } = renderModal({
-      onUploadList: jest.fn().mockRejectedValue(new Error('nope')),
-    });
-
-    await upload(makeFile('teams.csv'), container);
-
-    expect(await screen.findByRole('alert')).toHaveTextContent(
+    expect(screen.getByRole('alert')).toHaveTextContent(
       'Something went wrong reading this file. Please try again.',
     );
   });
@@ -348,13 +339,76 @@ describe('UploadListModal', () => {
 
     expect(
       await screen.findByText(
-        'All 3 Teams in this list are already in the attendance table.',
+        'All 3 teams in this list are already in the attendance table.',
       ),
     ).toBeInTheDocument();
     expect(screen.getByText('3 Teams')).toBeInTheDocument();
   });
 
-  it('Should explain an empty card when no team names were found', async () => {
+  it('Should not claim teams were already in after the user deletes them', async () => {
+    const { container } = renderModal({
+      onUploadList: jest.fn(async () => ({
+        matched: [{ teamId: 'm1', teamName: 'Imaging', attended: true }],
+        unmatched: [],
+      })),
+    });
+
+    await upload(makeFile('teams.csv'), container);
+    await userEvent.click(
+      await screen.findByRole('button', {
+        name: /will be added and marked if attended/,
+      }),
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Remove Imaging' }),
+    );
+
+    expect(screen.getByText('1 Team')).toBeInTheDocument();
+    expect(screen.queryByText(/already in the attendance table/)).toBeNull();
+    expect(screen.queryByText(/No team names found/)).toBeNull();
+  });
+
+  it('Should say "1 team" rather than "1 teams"', async () => {
+    const { container } = renderModal({
+      onUploadList: jest.fn(async () => ({
+        matched: [{ teamId: 'm1', teamName: 'Imaging', attended: true }],
+        unmatched: [],
+      })),
+    });
+
+    await upload(makeFile('teams.csv'), container);
+
+    expect(await screen.findByText('1 Team')).toBeInTheDocument();
+    expect(screen.getByText('1 team')).toBeInTheDocument();
+  });
+
+  it('Should flag an inactive matched team and open its link in a new tab', async () => {
+    const { container } = renderModal({
+      onUploadList: jest.fn(async () => ({
+        matched: [
+          {
+            teamId: 'm1',
+            teamName: 'Imaging',
+            attended: true,
+            isTeamInactive: true,
+          },
+        ],
+        unmatched: [],
+      })),
+      initialSectionsOpen: true,
+    });
+
+    await upload(makeFile('teams.csv'), container);
+
+    const link = await screen.findByRole('link', { name: 'Imaging' });
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    expect(
+      within(link.closest('div') as HTMLElement).getByTitle(/inactive/i),
+    ).toBeInTheDocument();
+  });
+
+  it('Should warn instead of showing zeroed counts when no names were found', async () => {
     const { container } = renderModal({
       onUploadList: jest.fn(async () => ({
         matched: [],
@@ -364,11 +418,32 @@ describe('UploadListModal', () => {
 
     await upload(makeFile('teams.csv'), container);
 
-    expect(
-      await screen.findByText(
-        'No Team names found. Check that the file has a Team column.',
-      ),
-    ).toBeInTheDocument();
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'No team names found. Check that the file has a Team Name column.',
+    );
+    expect(screen.queryByText('0 Teams')).not.toBeInTheDocument();
+    expect(screen.queryByText('0 matched')).not.toBeInTheDocument();
+  });
+
+  it('Should keep the size warning ahead of the empty-file warning', async () => {
+    const { container } = renderModal({
+      onUploadList: jest.fn(async () => ({
+        matched: [],
+        unmatched: [],
+      })),
+    });
+
+    const fileInput = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    await userEvent.upload(fileInput, [
+      makeFile('huge.csv', 11 * 1000 * 1000),
+      makeFile('empty.csv'),
+    ]);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The file size exceeds the limit of 10 MB. Please upload a smaller file.',
+    );
   });
 
   it('Should reset per-team edits when a new file is uploaded', async () => {

--- a/packages/react-components/src/organisms/__tests__/UploadListModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/UploadListModal.test.tsx
@@ -272,6 +272,88 @@ describe('UploadListModal', () => {
     expect(screen.queryByText('5 Teams')).not.toBeInTheDocument();
   });
 
+  it('Should show a read error when the upload parse fails', async () => {
+    const { container } = renderModal({
+      onUploadList: jest.fn().mockRejectedValue(new Error('nope')),
+    });
+
+    await upload(makeFile('teams.csv'), container);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Something went wrong reading this file. Please try again.',
+    );
+  });
+
+  it('Should clear the read error once a later upload succeeds', async () => {
+    const onUploadListRetry = jest
+      .fn<Promise<UploadListResult>, [File[]]>()
+      .mockRejectedValueOnce(new Error('nope'))
+      .mockResolvedValue(uploadResult);
+    const { container } = renderModal({ onUploadList: onUploadListRetry });
+
+    await upload(makeFile('first.csv'), container);
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+
+    await upload(makeFile('second.csv'), container);
+
+    expect(await screen.findByText('5 Teams')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('Should keep the size error visible when the valid file parses', async () => {
+    const { container } = renderModal();
+
+    const fileInput = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    await userEvent.upload(fileInput, [
+      makeFile('huge.csv', 11 * 1000 * 1000),
+      makeFile('fine.csv'),
+    ]);
+
+    expect(await screen.findByText('5 Teams')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'The file size exceeds the limit of 10 MB. Please upload a smaller file.',
+    );
+  });
+
+  it('Should explain an empty card when every team is already in', async () => {
+    const { container } = renderModal({
+      onUploadList: jest.fn(async () => ({
+        matched: [],
+        alreadyInCount: 3,
+        unmatched: [],
+      })),
+    });
+
+    await upload(makeFile('teams.csv'), container);
+
+    expect(
+      await screen.findByText(
+        'All 3 Teams in this list are already in the attendance table.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('3 Teams')).toBeInTheDocument();
+  });
+
+  it('Should explain an empty card when no team names were found', async () => {
+    const { container } = renderModal({
+      onUploadList: jest.fn(async () => ({
+        matched: [],
+        alreadyInCount: 0,
+        unmatched: [],
+      })),
+    });
+
+    await upload(makeFile('teams.csv'), container);
+
+    expect(
+      await screen.findByText(
+        'No Team names found. Check that the file has a Team column.',
+      ),
+    ).toBeInTheDocument();
+  });
+
   it('Should reset per-team edits when a new file is uploaded', async () => {
     const { container } = renderModal();
 

--- a/packages/react-components/src/organisms/__tests__/UploadListModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/UploadListModal.test.tsx
@@ -22,7 +22,10 @@ const uploadResult: UploadListResult = {
       teamType: 'Discovery Team',
     },
   ],
-  alreadyInCount: 2,
+  alreadyIn: [
+    { teamId: 'a1', teamName: 'Genetics', attended: true },
+    { teamId: 'a2', teamName: 'Proteomics', attended: false },
+  ],
   unmatched: [
     {
       name: 'Imagimg',
@@ -321,7 +324,11 @@ describe('UploadListModal', () => {
     const { container } = renderModal({
       onUploadList: jest.fn(async () => ({
         matched: [],
-        alreadyInCount: 3,
+        alreadyIn: [
+          { teamId: 'a1', teamName: 'A', attended: true },
+          { teamId: 'a2', teamName: 'B', attended: false },
+          { teamId: 'a3', teamName: 'C', attended: true },
+        ],
         unmatched: [],
       })),
     });
@@ -340,7 +347,7 @@ describe('UploadListModal', () => {
     const { container } = renderModal({
       onUploadList: jest.fn(async () => ({
         matched: [],
-        alreadyInCount: 0,
+        alreadyIn: [],
         unmatched: [],
       })),
     });
@@ -435,7 +442,7 @@ describe('UploadListModal', () => {
     const { container } = renderModal({
       onUploadList: jest.fn(async () => ({
         matched: uploadResult.matched,
-        alreadyInCount: 0,
+        alreadyIn: [],
         unmatched: [],
       })),
     });
@@ -454,7 +461,7 @@ describe('UploadListModal', () => {
     const { container } = renderModal({
       onUploadList: jest.fn(async () => ({
         matched: [],
-        alreadyInCount: 0,
+        alreadyIn: [],
         unmatched: uploadResult.unmatched,
       })),
     });
@@ -476,7 +483,35 @@ describe('UploadListModal', () => {
     );
 
     expect(onAddAttendees).toHaveBeenCalledWith(
-      [expect.objectContaining({ teamId: 'm1', teamName: 'Imaging' })],
+      [
+        expect.objectContaining({ teamId: 'm1', teamName: 'Imaging' }),
+        expect.objectContaining({ teamId: 'a1', attended: true }),
+        expect.objectContaining({ teamId: 'a2', attended: false }),
+      ],
+      [expect.objectContaining({ name: 'teams.csv' })],
+    );
+  });
+
+  it('Should let the user apply status updates when every team is already in', async () => {
+    const { container } = renderModal({
+      onUploadList: jest.fn(async () => ({
+        matched: [],
+        alreadyIn: [{ teamId: 'a1', teamName: 'Genetics', attended: false }],
+        unmatched: [],
+      })),
+    });
+
+    await upload(makeFile('teams.csv'), container);
+
+    const addButton = await screen.findByRole('button', {
+      name: 'Add Attendees',
+    });
+    expect(addButton).toBeEnabled();
+
+    await userEvent.click(addButton);
+
+    expect(onAddAttendees).toHaveBeenCalledWith(
+      [expect.objectContaining({ teamId: 'a1', attended: false })],
       [expect.objectContaining({ name: 'teams.csv' })],
     );
   });

--- a/packages/react-components/src/organisms/__tests__/UploadListModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/UploadListModal.test.tsx
@@ -104,6 +104,15 @@ describe('UploadListModal', () => {
     expect(screen.getByRole('button', { name: 'Add Attendees' })).toBeEnabled();
   });
 
+  it('Should treat every resolved team as new when currentTeamIds is omitted', async () => {
+    const { container } = renderModal({ currentTeamIds: undefined });
+
+    await upload(makeFile('teams.csv'), container);
+
+    expect(await screen.findByText('3 matched')).toBeInTheDocument();
+    expect(screen.getByText('0 already in')).toBeInTheDocument();
+  });
+
   it('Should render a seeded result without any upload', () => {
     renderModal({
       initialFiles: [makeFile('seeded.csv')],

--- a/packages/react-components/src/organisms/__tests__/UploadListModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/UploadListModal.test.tsx
@@ -357,6 +357,22 @@ describe('UploadListModal', () => {
     expect(screen.getByText('3 Teams')).toBeInTheDocument();
   });
 
+  it('Should name a single already-added team without counting it', async () => {
+    const { container } = renderModal({
+      currentTeamIds: new Set(['a1']),
+      onUploadList: jest.fn(async () => ({
+        matched: [{ teamId: 'a1', teamName: 'A', attended: true }],
+        unmatched: [],
+      })),
+    });
+
+    await upload(makeFile('teams.csv'), container);
+
+    expect(
+      await screen.findByText('This team is already in the attendance table.'),
+    ).toBeInTheDocument();
+  });
+
   it('Should not claim teams were already in after the user deletes them', async () => {
     const { container } = renderModal({
       onUploadList: jest.fn(async () => ({
@@ -378,20 +394,6 @@ describe('UploadListModal', () => {
     expect(screen.getByText('1 Team')).toBeInTheDocument();
     expect(screen.queryByText(/already in the attendance table/)).toBeNull();
     expect(screen.queryByText(/No team names found/)).toBeNull();
-  });
-
-  it('Should say "1 team" rather than "1 teams"', async () => {
-    const { container } = renderModal({
-      onUploadList: jest.fn(async () => ({
-        matched: [{ teamId: 'm1', teamName: 'Imaging', attended: true }],
-        unmatched: [],
-      })),
-    });
-
-    await upload(makeFile('teams.csv'), container);
-
-    expect(await screen.findByText('1 Team')).toBeInTheDocument();
-    expect(screen.getByText('1 team')).toBeInTheDocument();
   });
 
   it('Should flag an inactive matched team and open its link in a new tab', async () => {

--- a/packages/react-components/src/organisms/__tests__/UploadListModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/UploadListModal.test.tsx
@@ -89,6 +89,18 @@ describe('UploadListModal', () => {
     ).toBeDisabled();
   });
 
+  it('Should explain the expected file format in a tooltip', async () => {
+    renderModal();
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /info/i }));
+
+    expect(screen.getByRole('tooltip')).toHaveTextContent(
+      'Your file needs two columns.For team names, use the header Team.For attendance, use Attended.Mark attendance as yes/no.',
+    );
+  });
+
   it('Should upload a file and show the result summary and sections', async () => {
     const { container } = renderModal();
 

--- a/packages/react-components/src/utils/common.ts
+++ b/packages/react-components/src/utils/common.ts
@@ -16,6 +16,12 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export const noop = (): void => {};
 
+// Touch taps fire an emulated mouseenter right before the click, which would
+// flash a hover-only affordance on mobile; only hover-capable pointers count.
+export const canHover = (): boolean =>
+  typeof window.matchMedia !== 'function' ||
+  window.matchMedia('(hover: hover)').matches;
+
 export const getSvgAspectRatio = (element: React.ReactElement): number => {
   const markup = renderToStaticMarkup(element);
 

--- a/packages/react-components/src/utils/events.ts
+++ b/packages/react-components/src/utils/events.ts
@@ -4,3 +4,6 @@ import { parseISO, addHours } from 'date-fns';
 export function considerEndedAfter(endDate: string): Date {
   return addHours(parseISO(endDate), EVENT_CONSIDERED_PAST_HOURS_AFTER_EVENT);
 }
+
+export const pluralizeTeams = (count: number, capitalized = false): string =>
+  `${count} ${capitalized ? 'Team' : 'team'}${count === 1 ? '' : 's'}`;


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/browse/ASAP-1603

Lets Tech Support bulk add/update event attendance from CSV/XLSX files. Frontend-only, parsing and matching reuse 
the existing Algolia team index; no backend, model, or migration changes.

**In scope**

- Upload button + form; multiple files; 10 MB limit with error; cancel confirmation
- Parse Team + Attendance (Yes/No) columns
- Match names against the Hub; matched added with their status; unknown names shown as "not matched"
- Teams already on the table (including unsaved additions) updated in place, never duplicated
- Delete teams from the list

**Not in scope**

Saving/downloading the uploaded files (store the file, show + download source lists) → [ASAP-1605 Enable PMs to download Source files](https://asaphub.atlassian.net/browse/ASAP-1605)
Fuzzy “did you mean” suggestions for near-misses → [ASAP-1604 Enable PMs to manage Event Attendees ](https://asaphub.atlassian.net/browse/ASAP-1604)

**Happy path**

https://github.com/user-attachments/assets/4e644d47-25eb-46ca-a0b1-3fd37550b5d8

**Already added some teams**

https://github.com/user-attachments/assets/30c42fcc-db7a-4f19-878b-2f2426660f3b

**Too large**

https://github.com/user-attachments/assets/146ab41f-a2f5-4379-8fb8-73204f9dcf24


