### PR TITLE
[ASAP-1689] - Regression Draft output duplicate button not working

### DIFF
--- a/packages/react-components/src/templates/SharedResearchOutput.tsx
+++ b/packages/react-components/src/templates/SharedResearchOutput.tsx
@@ -81,10 +81,11 @@ const getDuplicateLink = ({
   id,
   publishingEntity,
   workingGroups,
+  teams,
   project,
 }: Pick<
   ResearchOutputResponse,
-  'id' | 'publishingEntity' | 'workingGroups' | 'project'
+  'id' | 'publishingEntity' | 'workingGroups' | 'teams' | 'project'
 >) => {
   switch (getResearchOutputEntityType({ publishingEntity })) {
     case 'working-group': {
@@ -100,6 +101,15 @@ const getDuplicateLink = ({
       const projectRoute = project && projectRouteByType[project.projectType];
       return project?.id && projectRoute
         ? projectRoute(project.id).duplicateOutput({ id }).$
+        : undefined;
+    }
+    case 'team': {
+      // Team outputs are duplicated through their linked project's route
+      const teamProject = teams[0]?.project;
+      const teamProjectRoute =
+        teamProject && projectRouteByType[teamProject.projectType];
+      return teamProject && teamProjectRoute
+        ? teamProjectRoute(teamProject.id).duplicateOutput({ id }).$
         : undefined;
     }
     default:
@@ -140,12 +150,15 @@ const SharedResearchOutput: React.FC<SharedResearchOutputProps> = ({
     props.documentType,
   );
 
+  const duplicateLink = getDuplicateLink({ id, ...props });
+
   const visibleActions = getVisibleResearchOutputActions(permissions, {
     published,
     isInReview,
     hasRelatedManuscript: !!relatedManuscriptVersion,
     isWorkingGroupOutput: !!(props.workingGroups && props.workingGroups[0]?.id),
     isGrantDocument,
+    hasDuplicateDestination: !!duplicateLink,
   });
 
   const tags = [
@@ -208,8 +221,6 @@ const SharedResearchOutput: React.FC<SharedResearchOutputProps> = ({
       setDisplayNoNewManuscriptVersionModal(true);
     }
   };
-
-  const duplicateLink = getDuplicateLink({ id, ...props });
 
   return (
     <div>

--- a/packages/react-components/src/templates/__tests__/SharedResearchOutput.test.tsx
+++ b/packages/react-components/src/templates/__tests__/SharedResearchOutput.test.tsx
@@ -1590,8 +1590,44 @@ describe('duplicate link', () => {
     );
   });
 
-  it('does not link when a project output is missing routing data', () => {
+  it('links a team-based project output to its project duplicate route', () => {
     const { getByTitle } = renderWithRouter(
+      <ResearchOutputPermissionsContext.Provider
+        value={{
+          canDuplicateResearchOutput: true,
+        }}
+      >
+        <SharedResearchOutput
+          {...props}
+          documentType="Article"
+          publishingEntity="Team"
+          workingGroups={undefined}
+          project={undefined}
+          teams={[
+            {
+              id: 'team-1',
+              displayName: 'Team 1',
+              teamType: 'Discovery Team',
+              project: {
+                id: 'project-1',
+                title: 'Discovery Project',
+                projectType: 'Discovery Project',
+                projectId: 'DP1',
+              },
+            },
+          ]}
+        />
+      </ResearchOutputPermissionsContext.Provider>,
+    );
+
+    expect(getByTitle('Duplicate').closest('a')).toHaveAttribute(
+      'href',
+      `/projects/discovery/project-1/duplicate/${props.id}`,
+    );
+  });
+
+  it('hides the duplicate button when a project output is missing routing data', () => {
+    const { queryByTitle } = renderWithRouter(
       <ResearchOutputPermissionsContext.Provider
         value={{
           canDuplicateResearchOutput: true,
@@ -1608,13 +1644,11 @@ describe('duplicate link', () => {
       </ResearchOutputPermissionsContext.Provider>,
     );
 
-    expect(
-      getByTitle('Duplicate').closest('a')?.getAttribute('href'),
-    ).toBeFalsy();
+    expect(queryByTitle('Duplicate')).toBeNull();
   });
 
-  it('does not link for team outputs', () => {
-    const { getByTitle } = renderWithRouter(
+  it('hides the duplicate button for team outputs without a linked project', () => {
+    const { queryByTitle } = renderWithRouter(
       <ResearchOutputPermissionsContext.Provider
         value={{
           canDuplicateResearchOutput: true,
@@ -1633,13 +1667,11 @@ describe('duplicate link', () => {
       </ResearchOutputPermissionsContext.Provider>,
     );
 
-    expect(
-      getByTitle('Duplicate').closest('a')?.getAttribute('href'),
-    ).toBeFalsy();
+    expect(queryByTitle('Duplicate')).toBeNull();
   });
 
-  it('does not link for an unknown publishing entity', () => {
-    const { getByTitle } = renderWithRouter(
+  it('hides the duplicate button for an unknown publishing entity', () => {
+    const { queryByTitle } = renderWithRouter(
       <ResearchOutputPermissionsContext.Provider
         value={{
           canDuplicateResearchOutput: true,
@@ -1656,9 +1688,7 @@ describe('duplicate link', () => {
       </ResearchOutputPermissionsContext.Provider>,
     );
 
-    expect(
-      getByTitle('Duplicate').closest('a')?.getAttribute('href'),
-    ).toBeFalsy();
+    expect(queryByTitle('Duplicate')).toBeNull();
   });
 
   it('renders output versions when versions are provided', () => {

--- a/packages/react-context/src/__tests__/permissions/research-output.test.tsx
+++ b/packages/react-context/src/__tests__/permissions/research-output.test.tsx
@@ -54,6 +54,7 @@ describe('getVisibleResearchOutputActions', () => {
     hasRelatedManuscript: false,
     isWorkingGroupOutput: false,
     isGrantDocument: false,
+    hasDuplicateDestination: true,
   };
 
   it('sets all actions to false if output is a grant document', () => {
@@ -194,6 +195,25 @@ describe('getVisibleResearchOutputActions', () => {
             ...state,
             isWorkingGroupOutput: false,
             hasRelatedManuscript: false,
+          },
+        ),
+      ).toEqual(
+        expect.objectContaining({
+          showDuplicate: false,
+        }),
+      );
+    });
+
+    it('sets showDuplicate to false if the output has no duplicate destination', () => {
+      expect(
+        getVisibleResearchOutputActions(
+          {
+            ...permissions,
+            canDuplicateResearchOutput: true,
+          },
+          {
+            ...state,
+            hasDuplicateDestination: false,
           },
         ),
       ).toEqual(

--- a/packages/react-context/src/permissions/research-output.ts
+++ b/packages/react-context/src/permissions/research-output.ts
@@ -102,6 +102,7 @@ export type ResearchOutputDetailState = {
   hasRelatedManuscript: boolean;
   isWorkingGroupOutput: boolean;
   isGrantDocument: boolean;
+  hasDuplicateDestination: boolean;
 };
 
 export const getVisibleResearchOutputActions = (
@@ -125,6 +126,7 @@ export const getVisibleResearchOutputActions = (
       (!state.isInReview || !!permissions.canPublishResearchOutput),
     showDuplicate:
       !!permissions.canDuplicateResearchOutput &&
+      state.hasDuplicateDestination &&
       (state.isWorkingGroupOutput || !state.hasRelatedManuscript),
     showRequestReview:
       !state.published && !!permissions.canRequestReview && !state.isInReview,


### PR DESCRIPTION
[ASAP-1689](https://asaphub.atlassian.net/browse/ASAP-1689)

[ASAP-1689]: https://asaphub.atlassian.net/browse/ASAP-1689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ