### PR TITLE
ASAP-1671 Add Metrics Tab to Teams and display Hub Research Outputs

### DIFF
--- a/apps/crn-frontend/src/analytics/productivity/__tests__/api.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/api.test.tsx
@@ -4,11 +4,16 @@ import {
   userProductivityResponse,
   teamProductivityPerformance,
 } from '@asap-hub/fixtures';
-import { SortTeamProductivity, SortUserProductivity } from '@asap-hub/model';
+import {
+  SortTeamProductivity,
+  SortUserProductivity,
+  TeamProductivityOpensearchDocument,
+} from '@asap-hub/model';
 import nock from 'nock';
 
 import { AnalyticsSearchOptionsWithFiltering } from '../../utils/analytics-options';
 import {
+  getTeamHubResearchOutputs,
   getTeamProductivity,
   getTeamProductivityPerformance,
   getUserProductivity,
@@ -673,5 +678,74 @@ describe('getUserProductivityPerformance', () => {
     });
 
     expect(result).toBeUndefined();
+  });
+});
+
+describe('getTeamHubResearchOutputs', () => {
+  const allDocument: TeamProductivityOpensearchDocument = {
+    ...teamProductivityResponse,
+    timeRange: 'all',
+    outputType: 'all',
+  };
+  const publicDocument: TeamProductivityOpensearchDocument = {
+    ...teamProductivityResponse,
+    Article: 1,
+    Bioinformatics: 0,
+    Dataset: 2,
+    'Lab Material': 2,
+    Protocol: 5,
+    timeRange: 'all',
+    outputType: 'public',
+  };
+
+  let opensearchClient: OpensearchClient<TeamProductivityOpensearchDocument>;
+  let searchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    opensearchClient = new OpensearchClient(
+      'team-productivity',
+      'Bearer test-token',
+    );
+    searchSpy = jest.spyOn(opensearchClient, 'search').mockResolvedValue({
+      items: [publicDocument, allDocument],
+      total: 2,
+    });
+  });
+
+  afterEach(() => {
+    searchSpy.mockRestore();
+  });
+
+  it('fetches both output types for the team in a single search', async () => {
+    await getTeamHubResearchOutputs(opensearchClient, { teamId: 'team-id-1' });
+
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    expect(searchSpy).toHaveBeenCalledWith({
+      searchTags: [],
+      searchScope: 'flat',
+      sort: [],
+      currentPage: 0,
+      pageSize: 2,
+      timeRange: 'all',
+      teamId: 'team-id-1',
+    });
+  });
+
+  it('splits the documents by output type', async () => {
+    const result = await getTeamHubResearchOutputs(opensearchClient, {
+      teamId: 'team-id-1',
+    });
+
+    expect(result).toEqual({ all: allDocument, public: publicDocument });
+  });
+
+  it('returns undefined for an output type with no document', async () => {
+    searchSpy.mockResolvedValue({ items: [allDocument], total: 1 });
+
+    const result = await getTeamHubResearchOutputs(opensearchClient, {
+      teamId: 'team-id-1',
+    });
+
+    expect(result).toEqual({ all: allDocument, public: undefined });
   });
 });

--- a/apps/crn-frontend/src/analytics/productivity/api.ts
+++ b/apps/crn-frontend/src/analytics/productivity/api.ts
@@ -5,8 +5,10 @@ import {
   UserProductivityPerformance,
   DocumentCategoryOption,
   OutputTypeOption,
+  outputTypes,
   TimeRangeOption,
   UserProductivityResponse,
+  TeamProductivityOpensearchDocument,
   TeamProductivityResponse,
 } from '@asap-hub/model';
 import {
@@ -162,6 +164,37 @@ export const getTeamProductivity = (
     sort: teamProductivityOpensearchSort[sort],
     outputType,
   });
+};
+
+export type TeamHubResearchOutputsOptions = {
+  teamId: string;
+};
+
+export type TeamHubResearchOutputs = {
+  all?: TeamProductivityOpensearchDocument;
+  public?: TeamProductivityOpensearchDocument;
+};
+
+const HUB_RESEARCH_OUTPUTS_TIME_RANGE: TimeRangeOption = 'all';
+
+export const getTeamHubResearchOutputs = async (
+  client: OpensearchClient<TeamProductivityOpensearchDocument>,
+  { teamId }: TeamHubResearchOutputsOptions,
+): Promise<TeamHubResearchOutputs> => {
+  const { items } = await client.search({
+    searchTags: [],
+    searchScope: 'flat',
+    sort: [],
+    currentPage: 0,
+    pageSize: outputTypes.length,
+    timeRange: HUB_RESEARCH_OUTPUTS_TIME_RANGE,
+    teamId,
+  });
+
+  return {
+    all: items.find(({ outputType }) => outputType === 'all'),
+    public: items.find(({ outputType }) => outputType === 'public'),
+  };
 };
 
 export const getUserProductivityPerformance = async (

--- a/apps/crn-frontend/src/analytics/productivity/state.ts
+++ b/apps/crn-frontend/src/analytics/productivity/state.ts
@@ -7,6 +7,7 @@ import {
   ListUserProductivityResponse,
   SortTeamProductivity,
   SortUserProductivity,
+  TeamProductivityOpensearchDocument,
   TeamProductivityPerformance,
   TeamProductivityResponse,
   UserProductivityPerformance,
@@ -17,10 +18,13 @@ import { AnalyticsSearchOptionsWithFiltering } from '../utils/analytics-options'
 import { useAnalyticsOpensearch } from '../../hooks/opensearch';
 import { makePerformanceQuery } from '../utils/state';
 import {
+  getTeamHubResearchOutputs,
   getTeamProductivity,
   getTeamProductivityPerformance,
   getUserProductivity,
   getUserProductivityPerformance,
+  TeamHubResearchOutputs,
+  TeamHubResearchOutputsOptions,
 } from './api';
 
 export const userProductivityQueryKeys = {
@@ -104,5 +108,26 @@ export const useAnalyticsTeamProductivity = (
         () => getTeamProductivity(opensearchClient, options),
         { total: 0, items: [] },
       ),
+  }).data;
+};
+
+export const teamHubResearchOutputsQueryKeys = {
+  all: ['analytics-team-hub-research-outputs'] as const,
+  detail: (teamId: string) =>
+    [...teamHubResearchOutputsQueryKeys.all, teamId] as const,
+};
+
+export const useTeamHubResearchOutputs = (
+  options: TeamHubResearchOutputsOptions,
+): TeamHubResearchOutputs => {
+  const opensearchClient =
+    useAnalyticsOpensearch<TeamProductivityOpensearchDocument>(
+      'team-productivity',
+    ).client;
+
+  return useSuspenseQuery({
+    queryKey: teamHubResearchOutputsQueryKeys.detail(options.teamId),
+    queryFn: (): Promise<TeamHubResearchOutputs> =>
+      getTeamHubResearchOutputs(opensearchClient, options),
   }).data;
 };

--- a/apps/crn-frontend/src/analytics/utils/opensearch/__tests__/query-builders.test.ts
+++ b/apps/crn-frontend/src/analytics/utils/opensearch/__tests__/query-builders.test.ts
@@ -573,6 +573,53 @@ describe('teamRecordSearchQueryBuilder', () => {
     expect(result.query.bool.must).toEqual([{ term: { timeRange: '30d' } }]);
   });
 
+  it('includes teamId in must clauses when provided', () => {
+    const result = teamRecordSearchQueryBuilder({
+      searchTags: [],
+      currentPage: 0,
+      pageSize: 10,
+      timeRange: 'all',
+      searchScope: 'flat',
+      teamId: 'team-id-1',
+    });
+
+    expect(result.query.bool.must).toEqual([
+      { term: { timeRange: 'all' } },
+      { term: { id: 'team-id-1' } },
+    ]);
+    expect(result.query.bool).not.toHaveProperty('should');
+  });
+
+  it('combines teamId and outputType in must clauses', () => {
+    const result = teamRecordSearchQueryBuilder({
+      searchTags: [],
+      currentPage: 0,
+      pageSize: 10,
+      timeRange: 'all',
+      searchScope: 'flat',
+      outputType: 'public',
+      teamId: 'team-id-1',
+    });
+
+    expect(result.query.bool.must).toEqual([
+      { term: { timeRange: 'all' } },
+      { term: { outputType: 'public' } },
+      { term: { id: 'team-id-1' } },
+    ]);
+  });
+
+  it('excludes teamId from must clauses when undefined', () => {
+    const result = teamRecordSearchQueryBuilder({
+      searchTags: [],
+      currentPage: 0,
+      pageSize: 10,
+      timeRange: 'all',
+      searchScope: 'flat',
+    });
+
+    expect(result.query.bool.must).toEqual([{ term: { timeRange: 'all' } }]);
+  });
+
   it('includes sort property when custom sort is provided', () => {
     const customSort = [{ Article: { order: 'asc' as const } }];
     const result = teamRecordSearchQueryBuilder({

--- a/apps/crn-frontend/src/analytics/utils/opensearch/client.ts
+++ b/apps/crn-frontend/src/analytics/utils/opensearch/client.ts
@@ -125,6 +125,7 @@ export class OpensearchClient<T> {
     documentCategory,
     sort,
     outputType,
+    teamId,
   }: Omit<OpensearchSearchOptions, 'currentPage' | 'pageSize'> & {
     currentPage?: number;
     pageSize?: number;
@@ -138,6 +139,7 @@ export class OpensearchClient<T> {
       searchTags,
       sort: sort as OpensearchSort[],
       outputType,
+      teamId,
     });
     const response = await this.request<OpensearchHitsResponse<T>>(searchQuery);
 

--- a/apps/crn-frontend/src/analytics/utils/opensearch/query-builders.ts
+++ b/apps/crn-frontend/src/analytics/utils/opensearch/query-builders.ts
@@ -192,6 +192,11 @@ export const teamRecordSearchQueryBuilder = (
       term: { outputType: options.outputType },
     });
   }
+  if (options.teamId) {
+    mustClauses.push({
+      term: { id: options.teamId },
+    });
+  }
 
   return {
     from: options.currentPage * options.pageSize,

--- a/apps/crn-frontend/src/analytics/utils/opensearch/types.ts
+++ b/apps/crn-frontend/src/analytics/utils/opensearch/types.ts
@@ -43,6 +43,7 @@ export type OpensearchSearchOptions = {
   documentCategory?: DocumentCategoryOption;
   sort?: OpensearchSort[];
   outputType?: OutputTypeOption;
+  teamId?: string;
 };
 
 type SortConfigOrder = 'asc' | 'desc';
@@ -132,7 +133,7 @@ export type ShouldClause =
     }
   | { match: Record<string, string> };
 
-type TermKey = 'timeRange' | 'documentCategory' | 'outputType';
+type TermKey = 'timeRange' | 'documentCategory' | 'outputType' | 'id';
 
 type ExclusiveRecord<K extends string, V> = {
   [P in K]: { [_ in P]: V } & { [O in Exclude<K, P>]?: never };

--- a/apps/crn-frontend/src/network/ProfileSwitch.tsx
+++ b/apps/crn-frontend/src/network/ProfileSwitch.tsx
@@ -13,7 +13,7 @@ const loadEventsList = () =>
 const EventsList = lazy(loadEventsList);
 
 type RequiredPaths = 'about' | 'upcoming' | 'past';
-type OptionalPaths = 'calendar' | 'outputs' | 'draftOutputs';
+type OptionalPaths = 'calendar' | 'outputs' | 'draftOutputs' | 'metrics';
 
 type ProfileSwitchProps = {
   About: FC;
@@ -22,6 +22,7 @@ type ProfileSwitchProps = {
   displayName: string;
   eventConstraint: EventConstraint;
   isActive?: boolean;
+  Metrics?: ReactElement;
   Outputs?: ReactElement;
   DraftOutputs?: ReactElement;
   paths: Record<RequiredPaths, string> & Partial<Record<OptionalPaths, string>>;
@@ -35,6 +36,7 @@ const ProfileSwitch: FC<ProfileSwitchProps> = ({
   displayName,
   eventConstraint,
   isActive,
+  Metrics,
   Outputs,
   paths,
   type,
@@ -48,6 +50,12 @@ const ProfileSwitch: FC<ProfileSwitchProps> = ({
           path={paths.about}
           element={<Frame title="About">{<About />}</Frame>}
         />
+        {Metrics && (
+          <Route
+            path={paths.metrics}
+            element={<Frame title="Metrics">{Metrics}</Frame>}
+          />
+        )}
         {isActive && Calendar && (
           <Route
             path={paths.calendar}

--- a/apps/crn-frontend/src/network/teams/TeamMetrics.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamMetrics.tsx
@@ -1,0 +1,17 @@
+import { TeamMetricsPage } from '@asap-hub/react-components';
+import { FC } from 'react';
+
+import { useTeamHubResearchOutputs } from '../../analytics/productivity/state';
+import { getHubResearchOutputRows } from './getHubResearchOutputRows';
+
+type TeamMetricsProps = {
+  teamId: string;
+};
+
+const TeamMetrics: FC<TeamMetricsProps> = ({ teamId }) => {
+  const { all, public: publicOutputs } = useTeamHubResearchOutputs({ teamId });
+  const hubResearchOutputRows = getHubResearchOutputRows(all, publicOutputs);
+  return <TeamMetricsPage hubResearchOutputRows={hubResearchOutputRows} />;
+};
+
+export default TeamMetrics;

--- a/apps/crn-frontend/src/network/teams/TeamProfile.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamProfile.tsx
@@ -3,7 +3,7 @@ import { Navigate, Route, Routes } from 'react-router';
 import { v4 as uuid } from 'uuid';
 
 import { NotFoundPage, TeamProfilePage } from '@asap-hub/react-components';
-import { useCurrentUserCRN } from '@asap-hub/react-context';
+import { useCurrentUserCRN, useFlags } from '@asap-hub/react-context';
 import { network, useRouteParams } from '@asap-hub/routing';
 
 import { useDismissable } from '../../hooks';
@@ -19,8 +19,11 @@ const loadAbout = () =>
   import(/* webpackChunkName: "network-team-about" */ './About');
 const loadEventsList = () =>
   import(/* webpackChunkName: "network-events" */ '../EventsEmbedList');
+const loadTeamMetrics = () =>
+  import(/* webpackChunkName: "network-team-metrics" */ './TeamMetrics');
 
 const About = lazy(loadAbout);
+const TeamMetrics = lazy(loadTeamMetrics);
 type TeamProfileProps = {
   currentTime: Date;
 };
@@ -36,8 +39,13 @@ const TeamProfile: FC<TeamProfileProps> = ({ currentTime }) => {
     'crn-team-project-banner-dismissed',
   );
 
+  const { isEnabled } = useFlags();
+
   const isStaff = user?.role === 'Staff';
   const isAsapTeam = team?.displayName === ASAP_TEAM_NAME;
+  const isTeamMember = !!user?.teams.some(({ id }) => id === teamId);
+  const canViewMetrics =
+    isEnabled('TEAM_METRICS_TAB') && (isStaff || isTeamMember);
 
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -49,11 +57,14 @@ const TeamProfile: FC<TeamProfileProps> = ({ currentTime }) => {
   });
 
   if (team) {
-    const { about, past, upcoming, workspace } = route({ teamId });
+    const { about, metrics, past, upcoming, workspace } = route({ teamId });
     const paths = {
       about: about.template.replace(/^\//, ''),
       past: past.template.replace(/^\//, ''),
       upcoming: upcoming.template.replace(/^\//, ''),
+      ...(canViewMetrics
+        ? { metrics: metrics.template.replace(/^\//, '') }
+        : {}),
     };
 
     return (
@@ -70,6 +81,7 @@ const TeamProfile: FC<TeamProfileProps> = ({ currentTime }) => {
                 {...team}
                 isStaff={isStaff}
                 isAsapTeam={isAsapTeam}
+                showMetricsTab={canViewMetrics}
                 teamListElementId={teamListElementId}
                 upcomingEventsCount={upcomingEvents?.total || 0}
                 pastEventsCount={pastEvents?.total || 0}
@@ -84,6 +96,9 @@ const TeamProfile: FC<TeamProfileProps> = ({ currentTime }) => {
                       isAsapTeam={isAsapTeam}
                     />
                   )}
+                  Metrics={
+                    canViewMetrics ? <TeamMetrics teamId={teamId} /> : undefined
+                  }
                   currentTime={currentTime}
                   displayName={team.displayName}
                   eventConstraint={{ teamId }}

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamMetrics.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamMetrics.test.tsx
@@ -1,0 +1,98 @@
+import { createTestQueryClient } from '@asap-hub/frontend-utils';
+import { TeamProductivityOpensearchDocument } from '@asap-hub/model';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { Suspense } from 'react';
+
+import { Auth0Provider, WhenReady } from '../../../auth/test-utils';
+import { getTeamHubResearchOutputs } from '../../../analytics/productivity/api';
+import TeamMetrics from '../TeamMetrics';
+
+jest.mock('../../../analytics/productivity/api');
+
+const mockGetTeamHubResearchOutputs =
+  getTeamHubResearchOutputs as jest.MockedFunction<
+    typeof getTeamHubResearchOutputs
+  >;
+
+const createDocument = (
+  overrides: Partial<TeamProductivityOpensearchDocument> = {},
+): TeamProductivityOpensearchDocument => ({
+  id: 'team-id-1',
+  name: 'Team 1',
+  isInactive: false,
+  Article: 0,
+  Bioinformatics: 0,
+  Dataset: 0,
+  'Lab Material': 0,
+  Protocol: 0,
+  timeRange: 'all',
+  outputType: 'all',
+  ...overrides,
+});
+
+afterEach(jest.clearAllMocks);
+
+const renderTab = async (teamId = 'team-id-1') => {
+  render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <Suspense fallback="loading">
+        <Auth0Provider user={{ id: 'user-id' }}>
+          <WhenReady>
+            <TeamMetrics teamId={teamId} />
+          </WhenReady>
+        </Auth0Provider>
+      </Suspense>
+    </QueryClientProvider>,
+  );
+  await waitFor(() =>
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
+  );
+};
+
+it('fetches the hub research outputs for the team', async () => {
+  mockGetTeamHubResearchOutputs.mockResolvedValue({});
+
+  await renderTab('t42');
+
+  expect(mockGetTeamHubResearchOutputs).toHaveBeenCalledWith(
+    expect.anything(),
+    { teamId: 't42' },
+  );
+});
+
+it('renders the metrics page', async () => {
+  mockGetTeamHubResearchOutputs.mockResolvedValue({});
+
+  await renderTab();
+
+  expect(
+    screen.getByRole('heading', { name: 'Metrics', level: 3 }),
+  ).toBeVisible();
+  expect(screen.getByText('Hub Research Outputs')).toBeVisible();
+});
+
+it('renders the counts and percentages', async () => {
+  mockGetTeamHubResearchOutputs.mockResolvedValue({
+    all: createDocument({ Article: 4 }),
+    public: createDocument({ outputType: 'public', Article: 3 }),
+  });
+
+  await renderTab();
+
+  const table = await screen.findByTestId('hub-research-outputs-table');
+  const row = within(table).getByText('Article').closest('tr');
+
+  expect(within(row!).getByText('4')).toBeVisible();
+  expect(within(row!).getByText('75%')).toBeVisible();
+});
+
+it('renders N/A when the team has no outputs', async () => {
+  mockGetTeamHubResearchOutputs.mockResolvedValue({});
+
+  await renderTab();
+
+  const table = await screen.findByTestId('hub-research-outputs-table');
+
+  expect(within(table).getAllByText('N/A')).toHaveLength(5);
+});

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamProfile.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamProfile.test.tsx
@@ -7,6 +7,7 @@ import {
   createTeamResponse,
 } from '@asap-hub/fixtures';
 import { TeamResponse } from '@asap-hub/model';
+import { disable, enable } from '@asap-hub/flags';
 import { network } from '@asap-hub/routing';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -15,6 +16,7 @@ import { createMemoryRouter, RouterProvider } from 'react-router';
 import { createTestQueryClient } from '@asap-hub/frontend-utils';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { getEvents } from '../../../events/api';
+import { getTeamHubResearchOutputs } from '../../../analytics/productivity/api';
 import { getTeam } from '../api';
 import TeamProfile from '../TeamProfile';
 
@@ -42,6 +44,7 @@ jest.mock('../api', () => ({
 jest.mock('../interest-groups/api');
 jest.mock('../../../shared-research/api');
 jest.mock('../../../events/api');
+jest.mock('../../../analytics/productivity/api');
 
 const mockGetEventsFromAlgolia = getEvents as jest.MockedFunction<
   typeof getEvents
@@ -304,5 +307,84 @@ describe('The project banner', () => {
     localStorage.setItem(dismissedKey, 'true');
     await renderPage(teamWithProject);
     expect(screen.queryByText(bannerText)).not.toBeInTheDocument();
+  });
+});
+
+describe('the metrics tab', () => {
+  const mockGetTeamHubResearchOutputs =
+    getTeamHubResearchOutputs as jest.MockedFunction<
+      typeof getTeamHubResearchOutputs
+    >;
+  const team = createTeamResponse();
+  const teamMember = {
+    teams: [{ id: team.id, role: 'Project Manager' as const }],
+  };
+
+  beforeEach(() => {
+    enable('TEAM_METRICS_TAB');
+    mockGetTeamHubResearchOutputs.mockResolvedValue({});
+  });
+
+  it('is shown to a member of the team', async () => {
+    await renderPage(team, {}, teamMember);
+
+    expect(screen.getByText('Metrics')).toBeVisible();
+  });
+
+  it('is shown to staff who are not on the team', async () => {
+    await renderPage(team, {}, { role: 'Staff' });
+
+    expect(screen.getByText('Metrics')).toBeVisible();
+  });
+
+  it('is hidden from a user who is neither staff nor on the team', async () => {
+    await renderPage(
+      team,
+      {},
+      { teams: [{ id: 'another-team', role: 'Project Manager' }] },
+    );
+
+    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+  });
+
+  it('is hidden when the flag is disabled', async () => {
+    disable('TEAM_METRICS_TAB');
+
+    await renderPage(team, {}, teamMember);
+
+    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+  });
+
+  it('renders the hub research outputs of the team', async () => {
+    await renderPage(
+      team,
+      {},
+      teamMember,
+      network({}).teams({}).team({ teamId: team.id }).metrics({}).$,
+    );
+
+    expect(
+      await screen.findByTestId('hub-research-outputs-table'),
+    ).toBeVisible();
+    expect(mockGetTeamHubResearchOutputs).toHaveBeenCalledWith(
+      expect.anything(),
+      { teamId: team.id },
+    );
+  });
+
+  it('does not render the metrics route when the flag is disabled', async () => {
+    disable('TEAM_METRICS_TAB');
+
+    await renderPage(
+      team,
+      {},
+      teamMember,
+      network({}).teams({}).team({ teamId: team.id }).metrics({}).$,
+    );
+
+    expect(
+      screen.queryByTestId('hub-research-outputs-table'),
+    ).not.toBeInTheDocument();
+    expect(mockGetTeamHubResearchOutputs).not.toHaveBeenCalled();
   });
 });

--- a/apps/crn-frontend/src/network/teams/__tests__/getHubResearchOutputRows.test.ts
+++ b/apps/crn-frontend/src/network/teams/__tests__/getHubResearchOutputRows.test.ts
@@ -1,0 +1,90 @@
+import { TeamProductivityOpensearchDocument } from '@asap-hub/model';
+
+import { getHubResearchOutputRows } from '../getHubResearchOutputRows';
+
+const createDocument = (
+  overrides: Partial<TeamProductivityOpensearchDocument> = {},
+): TeamProductivityOpensearchDocument => ({
+  id: 'team-id-1',
+  name: 'Team 1',
+  isInactive: false,
+  Article: 0,
+  Bioinformatics: 0,
+  Dataset: 0,
+  'Lab Material': 0,
+  Protocol: 0,
+  timeRange: 'all',
+  outputType: 'all',
+  ...overrides,
+});
+
+it('returns a row per output type in a stable order', () => {
+  const rows = getHubResearchOutputRows(createDocument(), createDocument());
+
+  expect(rows.map(({ outputType }) => outputType)).toEqual([
+    'Article',
+    'Bioinformatics',
+    'Dataset',
+    'Lab Material',
+    'Protocol',
+  ]);
+});
+
+it('reports the total from the all-outputs document', () => {
+  const rows = getHubResearchOutputRows(
+    createDocument({ Article: 4, Protocol: 10 }),
+    createDocument({ outputType: 'public', Article: 2, Protocol: 5 }),
+  );
+
+  expect(rows).toEqual([
+    { outputType: 'Article', numberOfOutputs: 4, publicPercentage: 50 },
+    {
+      outputType: 'Bioinformatics',
+      numberOfOutputs: 0,
+      publicPercentage: null,
+    },
+    { outputType: 'Dataset', numberOfOutputs: 0, publicPercentage: null },
+    { outputType: 'Lab Material', numberOfOutputs: 0, publicPercentage: null },
+    { outputType: 'Protocol', numberOfOutputs: 10, publicPercentage: 50 },
+  ]);
+});
+
+it('rounds the percentage', () => {
+  const rows = getHubResearchOutputRows(
+    createDocument({ Article: 3 }),
+    createDocument({ outputType: 'public', Article: 1 }),
+  );
+
+  expect(rows[0]).toEqual({
+    outputType: 'Article',
+    numberOfOutputs: 3,
+    publicPercentage: 33,
+  });
+});
+
+it('has no percentage to report when the team has no outputs of that type', () => {
+  const rows = getHubResearchOutputRows(
+    createDocument({ Article: 0 }),
+    createDocument({ outputType: 'public', Article: 0 }),
+  );
+
+  expect(rows[0]).toEqual({
+    outputType: 'Article',
+    numberOfOutputs: 0,
+    publicPercentage: null,
+  });
+});
+
+it('falls back to zeroes when the team is missing from the index', () => {
+  expect(getHubResearchOutputRows(undefined, undefined)).toEqual([
+    { outputType: 'Article', numberOfOutputs: 0, publicPercentage: null },
+    {
+      outputType: 'Bioinformatics',
+      numberOfOutputs: 0,
+      publicPercentage: null,
+    },
+    { outputType: 'Dataset', numberOfOutputs: 0, publicPercentage: null },
+    { outputType: 'Lab Material', numberOfOutputs: 0, publicPercentage: null },
+    { outputType: 'Protocol', numberOfOutputs: 0, publicPercentage: null },
+  ]);
+});

--- a/apps/crn-frontend/src/network/teams/getHubResearchOutputRows.ts
+++ b/apps/crn-frontend/src/network/teams/getHubResearchOutputRows.ts
@@ -1,0 +1,23 @@
+import {
+  teamOutputDocumentTypes,
+  TeamProductivityOpensearchDocument,
+} from '@asap-hub/model';
+import { HubResearchOutputRow } from '@asap-hub/react-components';
+
+export const getHubResearchOutputRows = (
+  all?: TeamProductivityOpensearchDocument,
+  publicOutputs?: TeamProductivityOpensearchDocument,
+): HubResearchOutputRow[] =>
+  teamOutputDocumentTypes.map((outputType) => {
+    const numberOfOutputs = all?.[outputType] ?? 0;
+    const numberOfPublicOutputs = publicOutputs?.[outputType] ?? 0;
+
+    return {
+      outputType,
+      numberOfOutputs,
+      publicPercentage:
+        numberOfOutputs === 0
+          ? null
+          : Math.round((numberOfPublicOutputs / numberOfOutputs) * 100),
+    };
+  });

--- a/apps/crn-server/scripts/opensearch/constants.ts
+++ b/apps/crn-server/scripts/opensearch/constants.ts
@@ -206,7 +206,7 @@ export const metricConfig: Record<Metrics, OpensearchMetricConfig> = {
     indexAlias: 'team-productivity',
     mapping: {
       properties: {
-        id: { type: 'text' },
+        id: { type: 'keyword' },
         name: textWithNgramKeyword({
           normalizer: 'lowercase_normalizer',
           raw: true,

--- a/packages/flags/src/index.ts
+++ b/packages/flags/src/index.ts
@@ -3,7 +3,8 @@ export type Flag =
   | 'QUERY_DEVTOOLS' // react query devtools
   | 'STAGING_MODE'
   | 'COMPLIANCE_NOTIFICATION_LIST'
-  | 'NEW_EVENT_PAGE';
+  | 'NEW_EVENT_PAGE'
+  | 'TEAM_METRICS_TAB';
 
 export type Flags = Partial<Record<Flag, boolean | string | undefined>>;
 let overrides: Flags = {
@@ -16,6 +17,7 @@ let overrides: Flags = {
   QUERY_DEVTOOLS: false,
   STAGING_MODE: false,
   NEW_EVENT_PAGE: false,
+  TEAM_METRICS_TAB: false,
 };
 
 const envDefaults: Record<string, boolean> = {

--- a/packages/model/src/analytics.ts
+++ b/packages/model/src/analytics.ts
@@ -373,6 +373,11 @@ export type UserProductivityResponse = UserProductivityDataObject;
 export type ListUserProductivityResponse =
   ListResponse<UserProductivityResponse>;
 
+export type TeamProductivityOpensearchDocument = TeamProductivityDataObject & {
+  timeRange: TimeRangeOption;
+  outputType: OutputTypeOption;
+};
+
 export type ListTeamProductivityDataObject =
   ListResponse<TeamProductivityDataObject>;
 export type TeamProductivityResponse = TeamProductivityDataObject;

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -356,6 +356,7 @@ export {
   TagsPage,
   TagsPageBody,
   TagsPageHeader,
+  TeamMetricsPage,
   TeamProfileAbout,
   TeamProfilePage,
   ToolModal,

--- a/packages/react-components/src/templates/TeamMetricsPage.tsx
+++ b/packages/react-components/src/templates/TeamMetricsPage.tsx
@@ -1,0 +1,47 @@
+import { css } from '@emotion/react';
+
+import { Headline3, Paragraph } from '../atoms';
+import { rem } from '../pixels';
+import { HubResearchOutputRow, HubResearchOutputsCard } from '../organisms';
+
+const containerStyles = css({
+  marginBottom: rem(56),
+});
+
+const subtitleContainer = css({
+  marginTop: rem(56),
+  marginBottom: rem(24),
+});
+
+const subtitle = css({
+  fontSize: rem(21),
+  fontWeight: 'bold',
+  lineHeight: rem(32),
+});
+
+const MetricsSubtitle = ({ children }: { children: string }) => (
+  <div css={subtitleContainer}>
+    <span css={subtitle}>{children}</span>
+  </div>
+);
+
+type TeamMetricsPageProps = {
+  readonly hubResearchOutputRows: HubResearchOutputRow[];
+};
+
+const TeamMetricsPage: React.FC<TeamMetricsPageProps> = ({
+  hubResearchOutputRows,
+}) => (
+  <div css={containerStyles}>
+    <Headline3 noMargin>Metrics</Headline3>
+    <Paragraph accent="lead">
+      Explore a high-level overview of your team's activity within the
+      Collaborative Research Network.
+    </Paragraph>
+
+    <MetricsSubtitle>Hub Research Outputs</MetricsSubtitle>
+    <HubResearchOutputsCard rows={hubResearchOutputRows} />
+  </div>
+);
+
+export default TeamMetricsPage;

--- a/packages/react-components/src/templates/TeamProfileHeader.tsx
+++ b/packages/react-components/src/templates/TeamProfileHeader.tsx
@@ -99,6 +99,7 @@ type TeamProfileHeaderProps = Readonly<Omit<TeamResponse, 'tools'>> & {
   readonly upcomingEventsCount?: number;
   readonly pastEventsCount?: number;
   readonly isAsapTeam?: boolean;
+  readonly showMetricsTab?: boolean;
 };
 
 const TeamProfileHeader: React.FC<TeamProfileHeaderProps> = ({
@@ -111,6 +112,7 @@ const TeamProfileHeader: React.FC<TeamProfileHeaderProps> = ({
   upcomingEventsCount,
   pastEventsCount,
   isAsapTeam = false,
+  showMetricsTab = false,
   teamStatus,
   teamType,
   resourceType,
@@ -152,6 +154,9 @@ const TeamProfileHeader: React.FC<TeamProfileHeaderProps> = ({
         nav={
           <TabNav>
             <TabLink href={route.about({}).$}>About</TabLink>
+            {showMetricsTab && (
+              <TabLink href={route.metrics({}).$}>Metrics</TabLink>
+            )}
             {isActive && (
               <TabLink href={route.upcoming({}).$}>
                 Upcoming Events {`(${upcomingEventsCount})`}

--- a/packages/react-components/src/templates/__tests__/TeamMetricsPage.test.tsx
+++ b/packages/react-components/src/templates/__tests__/TeamMetricsPage.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, within } from '@testing-library/react';
+import { ComponentProps } from 'react';
+import { TeamMetricsPage } from '..';
+
+describe('TeamMetricsPage', () => {
+  const props: ComponentProps<typeof TeamMetricsPage> = {
+    hubResearchOutputRows: [
+      { outputType: 'Article', numberOfOutputs: 4, publicPercentage: 75 },
+      { outputType: 'Protocol', numberOfOutputs: 0, publicPercentage: null },
+    ],
+  };
+
+  it('renders the heading and the introduction', () => {
+    render(<TeamMetricsPage {...props} />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Metrics', level: 3 }),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/high-level overview of your team's activity/i),
+    ).toBeVisible();
+  });
+
+  it('renders the hub research outputs section', () => {
+    render(<TeamMetricsPage {...props} />);
+
+    expect(screen.getByText('Hub Research Outputs')).toBeVisible();
+    expect(screen.getByTestId('hub-research-outputs-table')).toBeVisible();
+  });
+
+  it('renders a row per hub research output', () => {
+    render(<TeamMetricsPage {...props} />);
+    const table = screen.getByTestId('hub-research-outputs-table');
+
+    const articleRow = within(table).getByText('Article').closest('tr');
+    expect(within(articleRow!).getByText('4')).toBeVisible();
+    expect(within(articleRow!).getByText('75%')).toBeVisible();
+
+    const protocolRow = within(table).getByText('Protocol').closest('tr');
+    expect(within(protocolRow!).getByText('0')).toBeVisible();
+    expect(within(protocolRow!).getByText('N/A')).toBeVisible();
+  });
+
+  it('renders no rows when there are no hub research outputs', () => {
+    render(<TeamMetricsPage {...props} hubResearchOutputRows={[]} />);
+    const table = screen.getByTestId('hub-research-outputs-table');
+
+    expect(within(table).queryAllByRole('row')).toHaveLength(1);
+  });
+});

--- a/packages/react-components/src/templates/__tests__/TeamProfileHeader.test.tsx
+++ b/packages/react-components/src/templates/__tests__/TeamProfileHeader.test.tsx
@@ -331,3 +331,20 @@ it('renders breadcrumbs to the resource teams list', () => {
     breadcrumbs.getByRole('link', { name: 'Resource Teams' }),
   ).toHaveAttribute('href', network({}).resourceTeams({}).$);
 });
+
+it('does not render the metrics tab by default', () => {
+  render(<TeamProfileHeader {...boilerplateProps} />);
+
+  expect(
+    screen.queryByRole('link', { name: 'Metrics' }),
+  ).not.toBeInTheDocument();
+});
+
+it('renders a metrics tab linking to the team metrics when enabled', () => {
+  render(<TeamProfileHeader {...boilerplateProps} showMetricsTab />);
+
+  expect(screen.getByRole('link', { name: 'Metrics' })).toHaveAttribute(
+    'href',
+    network({}).teams({}).team({ teamId: boilerplateProps.id }).metrics({}).$,
+  );
+});

--- a/packages/react-components/src/templates/index.ts
+++ b/packages/react-components/src/templates/index.ts
@@ -92,6 +92,7 @@ export { default as SigninPage } from './SigninPage';
 export { default as TagsPage } from './TagsPage';
 export { default as TagsPageBody } from './TagsPageBody';
 export { default as TagsPageHeader } from './TagsPageHeader';
+export { default as TeamMetricsPage } from './TeamMetricsPage';
 export { default as TeamProfileAbout } from './TeamProfileAbout';
 export { default as TeamProfileHeader } from './TeamProfileHeader';
 export { default as TeamProfilePage } from './TeamProfilePage';

--- a/packages/routing/src/network.ts
+++ b/packages/routing/src/network.ts
@@ -85,6 +85,7 @@ export type OutputDocumentTypeParameter =
 
 const team = (() => {
   const about = route('/about', {}, {});
+  const metrics = route('/metrics', {}, {});
   const workspace = route('/workspace', {}, {});
 
   const createOutput = route(
@@ -101,6 +102,7 @@ const team = (() => {
     { teamId: stringParser },
     {
       about,
+      metrics,
       workspace,
       createOutput,
       upcoming,


### PR DESCRIPTION
This PR adds the new tab `Metrics` on the team page under a feature flag. To activate it, please run this

```
document.cookie = 'ASAP_TEAM_METRICS_TAB=true;'

location.reload()
```

on the browser console and verify it's in Application -> Cookies.


<img width="2480" height="2428" alt="Metrics _ Football and Society _ Team Profile _ ASAP Hub" src="https://github.com/user-attachments/assets/42fc76c2-6277-459c-b6b9-9264a5d7539b" />
