### PR TITLE
[ASAP-1692] - Fix false Manuscript Re-Submitted reminder on compliance report submission

### DIFF
--- a/apps/crn-server/src/data-providers/contentful/reminder.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/reminder.data-provider.ts
@@ -1202,7 +1202,7 @@ const getManuscriptRemindersFromQuery = (
       if (isStaffAndMemberOfOpenScienceTeam(user)) {
         if (
           isManuscriptResubmitted &&
-          inLast7Days(manuscriptItem.sys.publishedAt, timezone) &&
+          inLast7Days(manuscriptLastVersion.sys.firstPublishedAt, timezone) &&
           isReminderForDifferentUser(
             manuscriptLastVersion.createdBy?.sys.id,
             userId,
@@ -1225,7 +1225,7 @@ const getManuscriptRemindersFromQuery = (
 
       if (
         isManuscriptResubmitted &&
-        inLast7Days(manuscript.sys.publishedAt, timezone) &&
+        inLast7Days(manuscriptLastVersion.sys.firstPublishedAt, timezone) &&
         (isManuscriptAuthor(manuscriptLastVersion, userId) ||
           isManuscriptProjectManagerOrLeadPI(
             manuscript.teamsCollection,
@@ -1505,7 +1505,7 @@ const createManuscriptResubmittedReminder = (
       title: manuscript.title || '',
       teams: getManuscriptAssociationName(manuscript),
       resubmittedBy: `${lastVersion?.createdBy?.firstName} ${lastVersion?.createdBy?.lastName}`,
-      resubmittedAt: manuscript.sys.publishedAt,
+      resubmittedAt: lastVersion?.sys.firstPublishedAt,
     },
   };
 };

--- a/apps/crn-server/test/data-providers/contentful/reminders/manuscripts.reminder.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/contentful/reminders/manuscripts.reminder.data-provider.test.ts
@@ -580,6 +580,72 @@ describe('Reminders data provider', () => {
       });
     });
 
+    describe('Compliance report submission on a resubmitted manuscript', () => {
+      // A compliance report submission changes the manuscript status, which
+      // republishes the manuscript entry and bumps sys.publishedAt. A manuscript
+      // that was resubmitted more than 7 days ago must not re-surface a
+      // "Manuscript Resubmitted" reminder because of that later republish.
+      const manuscript = getContentfulReminderManuscriptCollectionItem();
+      manuscript!.sys.firstPublishedAt = '2024-12-01T00:00:00.000Z';
+      manuscript!.previousStatus = 'Manuscript Resubmitted';
+      manuscript!.status = 'Review Compliance Report';
+      manuscript!.statusUpdatedAt = '2025-01-08T10:00:00.000Z';
+      manuscript!.statusUpdatedBy = {
+        firstName: 'Jannet',
+        lastName: 'Doe',
+        sys: {
+          id: 'user-who-updated-manuscript-status',
+        },
+      };
+      manuscript!.teamsCollection!.items[0]!.displayName = 'ASAP';
+      manuscript!.versionsCollection = {
+        total: 2,
+        items: [
+          getManuscriptVersion({
+            count: 1,
+            firstAuthorIds: ['first-author-user'],
+            additionalAuthorIds: [],
+            correspondingAuthorIds: [],
+            createdById: 'user-who-created-manuscript',
+            createdByFirstName: 'Jane',
+            createdByLastName: 'Doe',
+            firstPublishedAt: '2024-12-01T00:00:00.000Z',
+          }),
+          getManuscriptVersion({
+            count: 2,
+            firstAuthorIds: ['first-author-user'],
+            additionalAuthorIds: [],
+            correspondingAuthorIds: [],
+            createdById: 'user-who-resubmitted-manuscript',
+            createdByFirstName: 'John',
+            createdByLastName: 'Doe',
+            firstPublishedAt: '2024-12-01T00:00:00.000Z',
+          }),
+        ],
+      };
+
+      test('shows the status change reminder but not a resubmission reminder', async () => {
+        const expectedStatusUpdatedReminder =
+          getManuscriptStatusUpdatedReminder();
+        expectedStatusUpdatedReminder.data.previousStatus =
+          'Manuscript Resubmitted';
+
+        mockContentfulGraphqlResponse(manuscript);
+
+        const result = await remindersDataProvider.fetch({
+          userId: 'first-author-user',
+          timezone,
+        });
+
+        expect(result.items).toEqual(
+          expect.arrayContaining([expectedStatusUpdatedReminder]),
+        );
+        expect(
+          result.items.some((item) => item.type === 'Manuscript Resubmitted'),
+        ).toBe(false);
+      });
+    });
+
     describe('User-based project manuscripts', () => {
       const projectName = 'Genetic Determinants of Progression';
       const fetchOptions = { timezone };
@@ -1018,6 +1084,9 @@ describe('Reminders data provider', () => {
           items: [
             {
               count: 1,
+              sys: {
+                firstPublishedAt: '2024-12-01T10:00:00.000Z',
+              },
               additionalAuthorsCollection: {
                 items: [],
               },
@@ -1044,6 +1113,9 @@ describe('Reminders data provider', () => {
             },
             {
               count: 2,
+              sys: {
+                firstPublishedAt: '2025-01-06T17:00:00.000Z',
+              },
               correspondingAuthorCollection: {
                 items: [],
               },

--- a/apps/crn-server/test/fixtures/reminders.fixtures.ts
+++ b/apps/crn-server/test/fixtures/reminders.fixtures.ts
@@ -580,6 +580,7 @@ export const getManuscriptVersion = ({
   createdByFirstName,
   createdByLastName,
   labPI = 'lab-pi-id',
+  firstPublishedAt = '2025-01-07T16:21:33.824Z',
 }: {
   count: number;
   firstAuthorIds: string[];
@@ -589,6 +590,7 @@ export const getManuscriptVersion = ({
   createdByFirstName: string;
   createdByLastName: string;
   labPI?: string;
+  firstPublishedAt?: string;
 }): NonNullable<
   NonNullable<
     NonNullable<
@@ -597,6 +599,9 @@ export const getManuscriptVersion = ({
   >['items'][number]
 > => ({
   count,
+  sys: {
+    firstPublishedAt,
+  },
   additionalAuthorsCollection: {
     items: additionalAuthorIds.map((id) => ({
       __typename: 'Users',

--- a/packages/contentful/src/crn/autogenerated-gql/graphql.ts
+++ b/packages/contentful/src/crn/autogenerated-gql/graphql.ts
@@ -67826,6 +67826,11 @@ export const FetchRemindersDocument = {
                             name: { kind: 'Name', value: 'limit' },
                             value: { kind: 'IntValue', value: '10' },
                           },
+                          {
+                            kind: 'Argument',
+                            name: { kind: 'Name', value: 'order' },
+                            value: { kind: 'EnumValue', value: 'count_ASC' },
+                          },
                         ],
                         selectionSet: {
                           kind: 'SelectionSet',

--- a/packages/contentful/src/crn/autogenerated-gql/graphql.ts
+++ b/packages/contentful/src/crn/autogenerated-gql/graphql.ts
@@ -36716,6 +36716,7 @@ export type FetchRemindersQuery = {
               items: Array<
                 Maybe<
                   Pick<ManuscriptVersions, 'count'> & {
+                    sys: Pick<Sys, 'firstPublishedAt'>;
                     createdBy?: Maybe<
                       Pick<Users, 'firstName' | 'lastName'> & {
                         sys: Pick<Sys, 'id'>;
@@ -67842,6 +67843,22 @@ export const FetchRemindersDocument = {
                                   {
                                     kind: 'Field',
                                     name: { kind: 'Name', value: 'count' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'sys' },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {
+                                          kind: 'Field',
+                                          name: {
+                                            kind: 'Name',
+                                            value: 'firstPublishedAt',
+                                          },
+                                        },
+                                      ],
+                                    },
                                   },
                                   {
                                     kind: 'Field',

--- a/packages/contentful/src/crn/queries/reminders.queries.ts
+++ b/packages/contentful/src/crn/queries/reminders.queries.ts
@@ -65,7 +65,7 @@ export const FETCH_REMINDERS = gql`
             }
           }
         }
-        versionsCollection(limit: 10) {
+        versionsCollection(limit: 10, order: count_ASC) {
           total
           items {
             count

--- a/packages/contentful/src/crn/queries/reminders.queries.ts
+++ b/packages/contentful/src/crn/queries/reminders.queries.ts
@@ -69,6 +69,9 @@ export const FETCH_REMINDERS = gql`
           total
           items {
             count
+            sys {
+              firstPublishedAt
+            }
             createdBy {
               sys {
                 id


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/browse/ASAP-1692

**Problem:** After sharing a compliance report, a false **"… resubmitted a manuscript … 'Manuscript Re-Submitted'"** reminder shows on the dashboard, even though no resubmission happened. It's dated to the compliance-report day, not the actual resubmission.

### How to reproduce (before the fix)

1. Take a manuscript resubmitted **> 7 days ago** (≥ 2 versions).
2. Share a compliance report on it today (republishes the manuscript).
3. Open the dashboard as a PM / author (not the person who resubmitted) → the false **"Manuscript Re-Submitted"** reminder appears, dated today.

### Cause
Sharing a report calls `manuscriptController.update({ status })`, which `patchAndPublish`es the manuscript and bumps `sys.publishedAt`. The reminder fired on `versions > 1 && inLast7Days(sys.publishedAt)` — with no check that a resubmission actually happened.

### Fix
Key the reminder off the **last version's `sys.firstPublishedAt`** (the real resubmission time), which doesn't move when the manuscript is later republished. Adds a regression test.

**Before:**

I just changed the compliance status:

<img width="878" height="369" alt="Screenshot 2026-09-03 at 08 51 14" src="https://github.com/user-attachments/assets/94ee3e62-4433-4c17-9e1a-f423395e3f18" />

**After:**

Note that the Resubmit notification is no longer displayed:

<img width="866" height="243" alt="Screenshot 2026-09-03 at 08 39 50" src="https://github.com/user-attachments/assets/e316b4c8-7acd-4145-b535-5f7b91432c8d" />
