### PR TITLE
[ASAP-1693] - Show the manuscript project name in discussion reminders

### DIFF
--- a/apps/crn-server/src/controllers/reminder.controller.ts
+++ b/apps/crn-server/src/controllers/reminder.controller.ts
@@ -24,6 +24,9 @@ export const formattedMaterialByEventType = (
   }
 };
 
+const discussionTeamPrefix = (teams: string): string =>
+  teams ? ` on **${teams}**` : '';
+
 export default class ReminderController {
   constructor(private reminderDataProvider: ReminderDataProvider) {}
 
@@ -196,7 +199,11 @@ export default class ReminderController {
                 manuscriptId: reminder.data.manuscriptId,
               }).$
             }?tab=discussions`,
-            description: `**${reminder.data.createdBy}** on **${reminder.data.manuscriptTeams}** started a discussion on:`,
+            description: `**${
+              reminder.data.createdBy
+            }**${discussionTeamPrefix(
+              reminder.data.manuscriptTeams,
+            )} started a discussion on:`,
             subtext: reminder.data.title,
             date: reminder.data.publishedAt,
           };
@@ -214,7 +221,11 @@ export default class ReminderController {
                 manuscriptId: reminder.data.manuscriptId,
               }).$
             }?tab=discussions`,
-            description: `**${reminder.data.createdBy}** on **${reminder.data.userTeams}** started a discussion on:`,
+            description: `**${
+              reminder.data.createdBy
+            }**${discussionTeamPrefix(
+              reminder.data.manuscriptTeams,
+            )} started a discussion on:`,
             subtext: reminder.data.title,
             date: reminder.data.publishedAt,
           };
@@ -232,7 +243,11 @@ export default class ReminderController {
                 manuscriptId: reminder.data.manuscriptId,
               }).$
             }?tab=discussions`,
-            description: `**${reminder.data.createdBy}** on **${reminder.data.manuscriptTeams}** replied to a discussion on:`,
+            description: `**${
+              reminder.data.createdBy
+            }**${discussionTeamPrefix(
+              reminder.data.manuscriptTeams,
+            )} replied to a discussion on:`,
             subtext: reminder.data.title,
             date: reminder.data.publishedAt,
           };
@@ -247,7 +262,11 @@ export default class ReminderController {
                 manuscriptId: reminder.data.manuscriptId,
               }).$
             }?tab=discussions`,
-            description: `**${reminder.data.createdBy}** on **${reminder.data.userTeams}** replied to a discussion on:`,
+            description: `**${
+              reminder.data.createdBy
+            }**${discussionTeamPrefix(
+              reminder.data.manuscriptTeams,
+            )} replied to a discussion on:`,
             subtext: reminder.data.title,
             date: reminder.data.publishedAt,
           };

--- a/apps/crn-server/src/controllers/reminder.controller.ts
+++ b/apps/crn-server/src/controllers/reminder.controller.ts
@@ -187,73 +187,10 @@ export default class ReminderController {
           };
         }
 
-        if (
-          reminder.entity === 'Discussion' &&
-          reminder.type === 'Discussion Created by Grantee'
-        ) {
-          return {
-            id: reminder.id,
-            entity: reminder.entity,
-            href: `${
-              compliance({}).manuscript({
-                manuscriptId: reminder.data.manuscriptId,
-              }).$
-            }?tab=discussions`,
-            description: `**${
-              reminder.data.createdBy
-            }**${discussionTeamPrefix(
-              reminder.data.manuscriptTeams,
-            )} started a discussion on:`,
-            subtext: reminder.data.title,
-            date: reminder.data.publishedAt,
-          };
-        }
-
-        if (
-          reminder.entity === 'Discussion' &&
-          reminder.type === 'Discussion Created by Open Science Member'
-        ) {
-          return {
-            id: reminder.id,
-            entity: reminder.entity,
-            href: `${
-              compliance({}).manuscript({
-                manuscriptId: reminder.data.manuscriptId,
-              }).$
-            }?tab=discussions`,
-            description: `**${
-              reminder.data.createdBy
-            }**${discussionTeamPrefix(
-              reminder.data.manuscriptTeams,
-            )} started a discussion on:`,
-            subtext: reminder.data.title,
-            date: reminder.data.publishedAt,
-          };
-        }
-
-        if (
-          reminder.entity === 'Discussion' &&
-          reminder.type === 'Discussion Replied To by Grantee'
-        ) {
-          return {
-            id: reminder.id,
-            entity: reminder.entity,
-            href: `${
-              compliance({}).manuscript({
-                manuscriptId: reminder.data.manuscriptId,
-              }).$
-            }?tab=discussions`,
-            description: `**${
-              reminder.data.createdBy
-            }**${discussionTeamPrefix(
-              reminder.data.manuscriptTeams,
-            )} replied to a discussion on:`,
-            subtext: reminder.data.title,
-            date: reminder.data.publishedAt,
-          };
-        }
-
         if (reminder.entity === 'Discussion') {
+          const isCreated =
+            reminder.type === 'Discussion Created by Grantee' ||
+            reminder.type === 'Discussion Created by Open Science Member';
           return {
             id: reminder.id,
             entity: reminder.entity,
@@ -262,11 +199,13 @@ export default class ReminderController {
                 manuscriptId: reminder.data.manuscriptId,
               }).$
             }?tab=discussions`,
-            description: `**${
-              reminder.data.createdBy
-            }**${discussionTeamPrefix(
+            description: `**${reminder.data.createdBy}**${discussionTeamPrefix(
               reminder.data.manuscriptTeams,
-            )} replied to a discussion on:`,
+            )} ${
+              isCreated
+                ? 'started a discussion on:'
+                : 'replied to a discussion on:'
+            }`,
             subtext: reminder.data.title,
             date: reminder.data.publishedAt,
           };

--- a/apps/crn-server/src/data-providers/contentful/reminder.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/reminder.data-provider.ts
@@ -1411,9 +1411,7 @@ export const getTeamNames = (
       ...new Set(teams.filter((teamName): teamName is string => !!teamName)),
     ].map((teamName) => `Team ${teamName}`);
 
-    if (teamNames.length === 0) return '';
-    if (teamNames.length === 1 && teamNames[0]) return teamNames[0];
-    if (teamNames.length === 2) return teamNames.join(' and ');
+    if (teamNames.length <= 2) return teamNames.join(' and ');
 
     return `${teamNames.slice(0, -1).join(', ')} and ${teamNames.slice(-1)}`;
   }

--- a/apps/crn-server/src/data-providers/contentful/reminder.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/reminder.data-provider.ts
@@ -1411,6 +1411,7 @@ export const getTeamNames = (
       ...new Set(teams.filter((teamName): teamName is string => !!teamName)),
     ].map((teamName) => `Team ${teamName}`);
 
+    if (teamNames.length === 0) return '';
     if (teamNames.length === 1 && teamNames[0]) return teamNames[0];
     if (teamNames.length === 2) return teamNames.join(' and ');
 
@@ -1516,9 +1517,6 @@ const createDiscussionCreatedReminder = (
 ): DiscussionCreatedReminder => {
   const manuscript = discussion.linkedFrom?.manuscriptsCollection?.items[0];
   const manuscriptVersion = manuscript?.versionsCollection?.items[0];
-  const userTeams = discussion.message.createdBy?.teamsCollection?.items.map(
-    (member) => member?.team?.displayName,
-  );
   const manuscriptTeams = getDiscussionManuscriptAssociationName(
     manuscript,
     manuscriptVersion as ManuscriptVersion,
@@ -1536,7 +1534,6 @@ const createDiscussionCreatedReminder = (
       title: manuscript?.title || '',
       manuscriptTeams,
       createdBy: `${discussion.message.createdBy.firstName} ${discussion.message.createdBy.lastName}`,
-      userTeams: getTeamNames(userTeams),
       publishedAt: discussion.sys.firstPublishedAt,
     },
   };
@@ -1555,9 +1552,6 @@ const createDiscussionRepliedToReminder = (
     manuscript,
     manuscriptVersion as ManuscriptVersion,
   );
-  const userTeams = message.createdBy?.teamsCollection?.items.map(
-    (member) => member?.team?.displayName,
-  );
 
   return {
     id: `discussion-replied-${message.sys.id}`,
@@ -1570,7 +1564,6 @@ const createDiscussionRepliedToReminder = (
       manuscriptId: manuscript?.sys.id || '',
       title: manuscript?.title || '',
       manuscriptTeams,
-      userTeams: getTeamNames(userTeams),
       createdBy: `${message.createdBy.firstName} ${message.createdBy.lastName}`,
       publishedAt: message.sys.firstPublishedAt,
     },

--- a/apps/crn-server/test/controllers/reminder.controller.test.ts
+++ b/apps/crn-server/test/controllers/reminder.controller.test.ts
@@ -531,9 +531,26 @@ describe('Reminder Controller', () => {
         const { items } = await reminderController.fetch(options);
         expect(items[0]).toMatchObject({
           description:
-            '**Tom Hardy** on **Team Alessi** started a discussion on:',
+            '**Tom Hardy** on **Team Reminder** started a discussion on:',
           href: '/compliance/manuscripts/manuscript-id-1?tab=discussions',
           subtext: 'Contextual AI models for single-cell protein biology',
+        });
+      });
+
+      test('Should omit the association when the manuscript has no resolvable name (started)', async () => {
+        const reminderDataObject =
+          getDiscussionStartedByOpenScienceMemberReminder();
+        reminderDataObject.data.manuscriptTeams = '';
+
+        reminderDataProviderMock.fetch.mockResolvedValueOnce({
+          total: 1,
+          items: [reminderDataObject],
+        });
+
+        const { items } = await reminderController.fetch(options);
+        expect(items[0]).toMatchObject({
+          description: '**Tom Hardy** started a discussion on:',
+          href: '/compliance/manuscripts/manuscript-id-1?tab=discussions',
         });
       });
 
@@ -565,9 +582,26 @@ describe('Reminder Controller', () => {
         const { items } = await reminderController.fetch(options);
         expect(items[0]).toMatchObject({
           description:
-            '**Tom Hardy** on **Team Alessi** replied to a discussion on:',
+            '**Tom Hardy** on **Team Reminder** replied to a discussion on:',
           href: '/compliance/manuscripts/manuscript-id-1?tab=discussions',
           subtext: 'Contextual AI models for single-cell protein biology',
+        });
+      });
+
+      test('Should omit the association when the manuscript has no resolvable name (replied)', async () => {
+        const reminderDataObject =
+          getDiscussionRepliedToByOpenScienceMemberReminder();
+        reminderDataObject.data.manuscriptTeams = '';
+
+        reminderDataProviderMock.fetch.mockResolvedValueOnce({
+          total: 1,
+          items: [reminderDataObject],
+        });
+
+        const { items } = await reminderController.fetch(options);
+        expect(items[0]).toMatchObject({
+          description: '**Tom Hardy** replied to a discussion on:',
+          href: '/compliance/manuscripts/manuscript-id-1?tab=discussions',
         });
       });
 

--- a/apps/crn-server/test/data-providers/contentful/reminders/discussions.reminder.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/contentful/reminders/discussions.reminder.data-provider.test.ts
@@ -286,54 +286,6 @@ describe('Reminders data provider', () => {
         expect(result.items).toEqual([expectedReminder]);
       });
 
-      test('does not repeat a team when the open science member has multiple roles in it', async () => {
-        const discussionItem = getContentfulReminderDiscussionCollectionItem();
-        const user = getContentfulReminderUsersContent();
-        discussionItem!.message!.createdBy = {
-          ...discussionItem!.message!.createdBy,
-          openScienceTeamMember: true,
-          role: 'Staff',
-          sys: { id: 'user-who-started-discussion' },
-          teamsCollection: {
-            items: [
-              {
-                team: {
-                  sys: { id: 'team-1' },
-                  displayName: 'Alessi',
-                  inactiveSince: null,
-                },
-              },
-              {
-                team: {
-                  sys: { id: 'team-2' },
-                  displayName: 'Ant',
-                  inactiveSince: null,
-                },
-              },
-              {
-                team: {
-                  sys: { id: 'team-1' },
-                  displayName: 'Alessi',
-                  inactiveSince: null,
-                },
-              },
-            ],
-          },
-        };
-
-        const fetchRemindersOptions: FetchRemindersOptions = {
-          userId: 'first-author-user',
-          timezone,
-        };
-
-        mockContentfulGraphqlResponse(discussionItem, user);
-
-        const result = await remindersDataProvider.fetch(fetchRemindersOptions);
-        expect(
-          (result.items[0] as DiscussionCreatedReminder).data.userTeams,
-        ).toEqual('Team Alessi and Team Ant');
-      });
-
       test('returns reminder if user is os member assigned to manuscript and discussion was started by grantee', async () => {
         const discussionItem = getContentfulReminderDiscussionCollectionItem();
         const expectedReminder = getDiscussionStartedByGranteeReminder();
@@ -732,6 +684,11 @@ describe('Reminders data provider', () => {
 
     test('getTeamNames ignores empty team names', async () => {
       expect(getTeamNames([null, undefined, 'Ant'])).toEqual('Team Ant');
+    });
+
+    test('getTeamNames returns empty string for an empty or all-empty list', async () => {
+      expect(getTeamNames([])).toEqual('');
+      expect(getTeamNames([null, undefined])).toEqual('');
     });
   });
 });

--- a/apps/crn-server/test/fixtures/reminders.fixtures.ts
+++ b/apps/crn-server/test/fixtures/reminders.fixtures.ts
@@ -840,7 +840,6 @@ export const getDiscussionStartedByGranteeReminder =
       createdBy: 'Tom Hardy',
       publishedAt: '2025-01-07T16:21:33.824Z',
       manuscriptTeams: 'Team Reminder',
-      userTeams: 'Team Alessi',
       title: 'Contextual AI models for single-cell protein biology',
     },
   });
@@ -855,7 +854,6 @@ export const getDiscussionStartedByOpenScienceMemberReminder =
       createdBy: 'Tom Hardy',
       publishedAt: '2025-01-07T16:21:33.824Z',
       manuscriptTeams: 'Team Reminder',
-      userTeams: 'Team Alessi',
       title: 'Contextual AI models for single-cell protein biology',
     },
   });
@@ -870,7 +868,6 @@ export const getDiscussionRepliedToByGranteeReminder =
       createdBy: 'Tom Hardy',
       publishedAt: '2025-01-07T16:21:33.824Z',
       manuscriptTeams: 'Team Reminder',
-      userTeams: 'Team Alessi',
       title: 'Contextual AI models for single-cell protein biology',
     },
   });
@@ -885,7 +882,6 @@ export const getDiscussionRepliedToByOpenScienceMemberReminder =
       createdBy: 'Tom Hardy',
       publishedAt: '2025-01-07T16:21:33.824Z',
       manuscriptTeams: 'Team Reminder',
-      userTeams: 'Team Alessi',
       title: 'Contextual AI models for single-cell protein biology',
     },
   });

--- a/packages/model/src/reminder.ts
+++ b/packages/model/src/reminder.ts
@@ -188,7 +188,6 @@ export interface DiscussionCreatedReminder extends Reminder {
     manuscriptId: ManuscriptDataObject['id'];
     title: ManuscriptDataObject['title'];
     manuscriptTeams: string;
-    userTeams: string;
     createdBy: string;
     publishedAt: string;
   };
@@ -203,7 +202,6 @@ export interface DiscussionRepliedToReminder extends Reminder {
     manuscriptId: ManuscriptDataObject['id'];
     title: ManuscriptDataObject['title'];
     manuscriptTeams: string;
-    userTeams: string;
     createdBy: string;
     publishedAt: string;
   };


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/browse/ASAP-1693

If a user without a team comments on a discussion, you will see it

**Before:**

<img width="1071" height="121" alt="Screenshot 2026-09-04 at 16 08 41" src="https://github.com/user-attachments/assets/f7ea947f-12db-4b2c-b425-7a3a10bcbd01" />

**After:**

<img width="1086" height="130" alt="Screenshot 2026-09-04 at 16 35 46" src="https://github.com/user-attachments/assets/855c90b3-f204-4bfd-8f36-f37952f18db3" />

