### PR TITLE
[ASAP] - Remove hardcoded GitHub org

### DIFF
--- a/.github/scripts/manage-workflows/delete-workflow-runs.sh
+++ b/.github/scripts/manage-workflows/delete-workflow-runs.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-OWNER=yldio
-REPO=asap-hub
-
 die () {
     echo >&2 "$@"
     exit 1
@@ -13,4 +10,4 @@ echo $1 | grep -E -q '^[0-9]+$' || die "Numeric argument required, $1 provided"
 WORKFLOW_ID=$1
 
 # delete runs (you'll have to run this multiple times if there's many because of pagination)
-gh api -X GET /repos/$OWNER/$REPO/actions/workflows/$WORKFLOW_ID/runs | jq '.workflow_runs[] | .id' | xargs -n1 -I % gh api --silent -X DELETE /repos/$OWNER/$REPO/actions/runs/%
+gh api -X GET /repos/{owner}/{repo}/actions/workflows/$WORKFLOW_ID/runs | jq '.workflow_runs[] | .id' | xargs -n1 -I % gh api --silent -X DELETE /repos/{owner}/{repo}/actions/runs/%

--- a/.github/scripts/manage-workflows/list-workflows.sh
+++ b/.github/scripts/manage-workflows/list-workflows.sh
@@ -1,6 +1,3 @@
 #!/bin/bash
-OWNER=yldio
-REPO=asap-hub
-
 # list workflows
-gh api -X GET /repos/$OWNER/$REPO/actions/workflows | jq '.workflows[] | .name,.id,.path'
+gh api -X GET /repos/{owner}/{repo}/actions/workflows | jq '.workflows[] | .name,.id,.path'

--- a/.github/workflows/on-remove.yml
+++ b/.github/workflows/on-remove.yml
@@ -21,7 +21,7 @@ jobs:
   # Removed before crn-sls-remove: the async stack's event source mappings
   # reference queues owned by the asap-hub stack.
   crn-async-sls-remove:
-    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == 'yldio/asap-hub' }}
+    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/yldio/asap-hub/node-python-sq:92bd02a49ed4fd0c99c86d1966869791bc1530fe
@@ -60,7 +60,7 @@ jobs:
           sls-stage: ${{ steps.setup.outputs.sls-stage}}
 
   crn-indexers-sls-remove:
-    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == 'yldio/asap-hub' }}
+    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/yldio/asap-hub/node-python-sq:92bd02a49ed4fd0c99c86d1966869791bc1530fe
@@ -100,7 +100,7 @@ jobs:
 
   crn-sls-remove:
     needs: [crn-async-sls-remove, crn-indexers-sls-remove]
-    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == 'yldio/asap-hub' }}
+    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/yldio/asap-hub/node-python-sq:92bd02a49ed4fd0c99c86d1966869791bc1530fe
@@ -137,7 +137,7 @@ jobs:
           sls-stage: ${{ steps.setup.outputs.sls-stage}}
 
   gp2-sls-remove:
-    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == 'yldio/asap-hub' }}
+    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/yldio/asap-hub/node-python-sq:92bd02a49ed4fd0c99c86d1966869791bc1530fe
@@ -174,7 +174,7 @@ jobs:
           sls-stage: ${{ steps.setup.outputs.sls-stage}}
 
   crn-contentful-remove:
-    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == 'yldio/asap-hub' }}
+    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/yldio/asap-hub/node-python-sq:92bd02a49ed4fd0c99c86d1966869791bc1530fe
@@ -215,7 +215,7 @@ jobs:
           CONTENTFUL_SPACE_ID: ${{ steps.setup.outputs.crn-contentful-space-id }}
 
   gp2-contentful-remove:
-    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == 'yldio/asap-hub' }}
+    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/yldio/asap-hub/node-python-sq:92bd02a49ed4fd0c99c86d1966869791bc1530fe
@@ -256,7 +256,7 @@ jobs:
           CONTENTFUL_SPACE_ID: ${{ steps.setup.outputs.gp2-contentful-space-id }}
 
   crn-algolia-index:
-    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == 'yldio/asap-hub' }}
+    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/yldio/asap-hub/node-python-sq:92bd02a49ed4fd0c99c86d1966869791bc1530fe
@@ -304,7 +304,7 @@ jobs:
           ALGOLIA_INDEX: ${{ steps.setup.outputs.crn-algolia-index }}
 
   gp2-algolia-index:
-    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == 'yldio/asap-hub' }}
+    if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/yldio/asap-hub/node-python-sq:92bd02a49ed4fd0c99c86d1966869791bc1530fe
@@ -364,7 +364,7 @@ jobs:
         gp2-contentful-remove,
         gp2-sls-remove,
       ]
-    if: ${{ failure() && (github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == 'yldio/asap-hub') }}
+    if: ${{ failure() && (github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Removes hardcoded `yldio/asap-hub` references from the workflow tooling ahead of the org transfer. `on-remove.yml `now compares the PR head repo against `github.repository`, so PR cleanup keeps running after the move. The manage-workflows helper scripts no longer hardcode the owner and repo; `gh` fills them in from the checkout's git remote.