### PR TITLE
[ASAP] - Fix Sentry release script crash and GP2 project slug

### DIFF
--- a/apps/crn-frontend/scripts/sentry-release.js
+++ b/apps/crn-frontend/scripts/sentry-release.js
@@ -9,15 +9,17 @@ async function createReleaseAndUpload() {
   }
   const cli = new SentryCli(null, {
     authToken: process.env.FRONTEND_SENTRY_RELEASE_AUTH_TOKEN,
-    org: 'coalitionforaligningscience',
+    // numeric org id: immune to slug renames
+    org: '850903',
     project: 'asap-hub-frontend',
   });
   try {
     const release = process.env.FRONTEND_RELEASE;
     console.log('Creating sentry release ' + release);
     await cli.releases.new(release);
+    console.log('Associating commits');
+    await cli.releases.setCommits(release, { auto: true, ignoreMissing: true });
     console.log('Uploading source maps');
-    cli.releases.setCommits(release, { auto: true });
     await cli.releases.uploadSourceMaps(release, {
       include: ['build/static/js'],
       urlPrefix: '~/static/js',

--- a/apps/gp2-frontend/scripts/sentry-release.js
+++ b/apps/gp2-frontend/scripts/sentry-release.js
@@ -9,15 +9,17 @@ async function createReleaseAndUpload() {
   }
   const cli = new SentryCli(null, {
     authToken: process.env.FRONTEND_SENTRY_RELEASE_AUTH_TOKEN,
-    org: 'coalitionforaligningscience',
-    project: 'asap-hub-frontend',
+    // numeric org id: immune to slug renames
+    org: '850903',
+    project: 'gp2-hub-frontend',
   });
   try {
     const release = process.env.FRONTEND_RELEASE;
     console.log('Creating sentry release ' + release);
     await cli.releases.new(release);
+    console.log('Associating commits');
+    await cli.releases.setCommits(release, { auto: true, ignoreMissing: true });
     console.log('Uploading source maps');
-    cli.releases.setCommits(release, { auto: true });
     await cli.releases.uploadSourceMaps(release, {
       include: ['build/static/js'],
       urlPrefix: '~/static/js',


### PR DESCRIPTION
 Fixes the Sentry release step, which had been failing silently since before the org transfer (expired token, now replaced) and crashed once a working token was in place.

- Await the set-commits call inside the try block with ignoreMissing: true. It was fired without await, so a missing previous-release commit became an unhandled rejection and killed the job.

- GP2 releases were registered against the CRN project; use gp2-hub-frontend.

- Reference the Sentry org by numeric `id` so `slug` renames no longer affect the scripts.

Verify on the first master deploy after merge: verify-* / register-release should go green with "Associating commits", "Uploading source maps" and "Finalizing release" in the log.