### PR TITLE
WIP - Support interest groups in Contentful attendance editor

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -143,6 +143,10 @@ const RAW_RUNTIME_STATE =
       "reference": "workspace:packages/contentful-app-extensions/event-additional-materials"\
     },\
     {\
+      "name": "@asap-hub/contentful-app-event-attendance",\
+      "reference": "workspace:packages/contentful-app-extensions/event-attendance"\
+    },\
+    {\
       "name": "@asap-hub/contentful-app-event-custom-validation",\
       "reference": "workspace:packages/contentful-app-extensions/event-custom-validation"\
     },\
@@ -277,6 +281,7 @@ const RAW_RUNTIME_STATE =
     ["@asap-hub/contentful-app-date-field-as-last-published-at", ["workspace:packages/contentful-app-extensions/date-field-as-last-published-at"]],\
     ["@asap-hub/contentful-app-disabled-fields", ["workspace:packages/contentful-app-extensions/disabled-fields"]],\
     ["@asap-hub/contentful-app-event-additional-materials", ["workspace:packages/contentful-app-extensions/event-additional-materials"]],\
+    ["@asap-hub/contentful-app-event-attendance", ["workspace:packages/contentful-app-extensions/event-attendance"]],\
     ["@asap-hub/contentful-app-event-custom-validation", ["workspace:packages/contentful-app-extensions/event-custom-validation"]],\
     ["@asap-hub/contentful-app-event-speakers-gp2", ["workspace:packages/contentful-app-extensions/event-speakers-gp2"]],\
     ["@asap-hub/contentful-app-event-speakers-title", ["workspace:packages/contentful-app-extensions/event-speakers-title"]],\
@@ -466,6 +471,10 @@ const RAW_RUNTIME_STATE =
     [\
       "@asap-hub/contentful-app-event-additional-materials",\
       "workspace:packages/contentful-app-extensions/event-additional-materials"\
+    ],\
+    [\
+      "@asap-hub/contentful-app-event-attendance",\
+      "workspace:packages/contentful-app-extensions/event-attendance"\
     ],\
     [\
       "@asap-hub/contentful-app-event-custom-validation",\
@@ -12299,6 +12308,36 @@ const RAW_RUNTIME_STATE =
           ["@contentful/app-sdk", "npm:4.51.0"],\
           ["@contentful/f36-components", "virtual:1d47b7e957e0138f6086a7faebe847e5508e2838ed66681182f829fb247165a9e7d2dedfdb5253efd814664c91c8a9a71d0a25de245f4f0502c8f6aa12f72ac5#npm:4.81.1"],\
           ["@contentful/f36-tokens", "npm:4.2.0"],\
+          ["@contentful/react-apps-toolkit", "virtual:1d47b7e957e0138f6086a7faebe847e5508e2838ed66681182f829fb247165a9e7d2dedfdb5253efd814664c91c8a9a71d0a25de245f4f0502c8f6aa12f72ac5#npm:1.2.23"],\
+          ["@testing-library/dom", "npm:10.4.1"],\
+          ["@testing-library/jest-dom", "npm:6.9.1"],\
+          ["@testing-library/react", "virtual:70ee702ae21962651e36bbfc38610149cb09f8829834f72efabf6ff499ef36bdf828f0ce38bc9269076bac68bed4fbc3b604042ba63016aed4c3a27d5308300f#npm:16.3.2"],\
+          ["@types/jest", "npm:29.5.14"],\
+          ["@types/node", "npm:20.10.5"],\
+          ["@types/react", "npm:18.3.12"],\
+          ["@types/react-dom", "npm:18.3.1"],\
+          ["contentful-management", "npm:10.46.4"],\
+          ["cross-env", "npm:7.0.3"],\
+          ["emotion", "npm:10.0.27"],\
+          ["react", "npm:18.3.1"],\
+          ["react-dom", "virtual:70ee702ae21962651e36bbfc38610149cb09f8829834f72efabf6ff499ef36bdf828f0ce38bc9269076bac68bed4fbc3b604042ba63016aed4c3a27d5308300f#npm:18.3.1"],\
+          ["react-scripts", "virtual:1d47b7e957e0138f6086a7faebe847e5508e2838ed66681182f829fb247165a9e7d2dedfdb5253efd814664c91c8a9a71d0a25de245f4f0502c8f6aa12f72ac5#npm:5.0.1"],\
+          ["typescript", "patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"]\
+        ],\
+        "linkType": "SOFT"\
+      }]\
+    ]],\
+    ["@asap-hub/contentful-app-event-attendance", [\
+      ["workspace:packages/contentful-app-extensions/event-attendance", {\
+        "packageLocation": "./packages/contentful-app-extensions/event-attendance/",\
+        "packageDependencies": [\
+          ["@asap-hub/contentful-app-event-attendance", "workspace:packages/contentful-app-extensions/event-attendance"],\
+          ["@contentful/app-scripts", "npm:1.33.2"],\
+          ["@contentful/app-sdk", "npm:4.51.0"],\
+          ["@contentful/f36-components", "virtual:1d47b7e957e0138f6086a7faebe847e5508e2838ed66681182f829fb247165a9e7d2dedfdb5253efd814664c91c8a9a71d0a25de245f4f0502c8f6aa12f72ac5#npm:4.81.1"],\
+          ["@contentful/f36-tokens", "npm:4.2.0"],\
+          ["@contentful/field-editor-reference", "virtual:19c9f708eca3d47369c1a0ea590c8ca8f7067323538872cc7586d47ecab0ec157f1339899ca30aae318e9507d0d5eb8339ded949aeb54107c3939c310f8690d3#npm:5.31.2"],\
+          ["@contentful/field-editor-shared", "virtual:ac51f6958473b2bd22f1df8642b4a32b954b15870dc002d2612804e42829036d3cb69caf6262adc26e7473cb81d46f7934acfd58e30152bb5cdc4ff0a889ac2a#npm:1.8.0"],\
           ["@contentful/react-apps-toolkit", "virtual:1d47b7e957e0138f6086a7faebe847e5508e2838ed66681182f829fb247165a9e7d2dedfdb5253efd814664c91c8a9a71d0a25de245f4f0502c8f6aa12f72ac5#npm:1.2.23"],\
           ["@testing-library/dom", "npm:10.4.1"],\
           ["@testing-library/jest-dom", "npm:6.9.1"],\

--- a/packages/contentful-app-extensions/event-attendance/package.json
+++ b/packages/contentful-app-extensions/event-attendance/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@asap-hub/contentful-app-event-attendance",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@contentful/app-sdk": "4.51.0",
+    "@contentful/f36-components": "4.81.1",
+    "@contentful/f36-tokens": "4.2.0",
+    "@contentful/field-editor-reference": "^5.9.0",
+    "@contentful/field-editor-shared": "^1.2.0",
+    "@contentful/react-apps-toolkit": "1.2.23",
+    "contentful-management": "10.46.4",
+    "emotion": "10.0.27",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "cross-env BROWSER=none react-scripts start",
+    "build": "GENERATE_SOURCEMAP=false DISABLE_ESLINT_PLUGIN=true react-scripts build",
+    "test": "react-scripts test",
+    "test:no-watch": "react-scripts test --watchAll=false",
+    "eject": "react-scripts eject",
+    "create-app-definition": "contentful-app-scripts create-app-definition",
+    "upload": "contentful-app-scripts upload --bundle-dir ./build",
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "devDependencies": {
+    "@contentful/app-scripts": "1.33.2",
+    "@testing-library/dom": "10.4.1",
+    "@testing-library/jest-dom": "^6.9.0",
+    "@testing-library/react": "16.3.2",
+    "@types/jest": "29.5.14",
+    "@types/node": "20.10.5",
+    "@types/react": "18.3.12",
+    "@types/react-dom": "18.3.1",
+    "cross-env": "7.0.3",
+    "typescript": "4.9.5"
+  },
+  "homepage": "."
+}

--- a/packages/contentful-app-extensions/event-attendance/public/index.html
+++ b/packages/contentful-app-extensions/event-attendance/public/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/packages/contentful-app-extensions/event-attendance/src/App.tsx
+++ b/packages/contentful-app-extensions/event-attendance/src/App.tsx
@@ -1,0 +1,19 @@
+import React, { useMemo } from 'react';
+import { locations } from '@contentful/app-sdk';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import Field from './locations/Field';
+
+const App = () => {
+  const sdk = useSDK();
+
+  const Component = useMemo(() => {
+    if (sdk.location.is(locations.LOCATION_ENTRY_FIELD)) {
+      return Field;
+    }
+    return null;
+  }, [sdk.location]);
+
+  return Component ? <Component /> : null;
+};
+
+export default App;

--- a/packages/contentful-app-extensions/event-attendance/src/index.tsx
+++ b/packages/contentful-app-extensions/event-attendance/src/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import { GlobalStyles } from '@contentful/f36-components';
+import { SDKProvider } from '@contentful/react-apps-toolkit';
+
+import App from './App';
+
+const root = document.getElementById('root');
+
+render(
+  <SDKProvider>
+    <GlobalStyles />
+    <App />
+  </SDKProvider>,
+  root,
+);

--- a/packages/contentful-app-extensions/event-attendance/src/locations/Field.tsx
+++ b/packages/contentful-app-extensions/event-attendance/src/locations/Field.tsx
@@ -1,0 +1,274 @@
+import React, { useState } from 'react';
+import {
+  MultipleEntryReferenceEditor,
+  CustomEntityCardProps,
+  useEntity,
+} from '@contentful/field-editor-reference';
+import { entityHelpers } from '@contentful/field-editor-shared';
+import {
+  EntryCard,
+  MenuItem,
+  Badge,
+  Button,
+  Heading,
+  Text,
+  EntityStatus,
+  EntryCardProps,
+  Box,
+  Stack,
+  formatRelativeDateTime,
+} from '@contentful/f36-components';
+import { FieldExtensionSDK, Entry, Link } from '@contentful/app-sdk';
+import {
+  useSDK,
+  useCMA,
+  useAutoResizer,
+} from '@contentful/react-apps-toolkit';
+
+const LOCALE = 'en-US';
+
+const entryLink = (id: string): Link => ({
+  sys: { type: 'Link', linkType: 'Entry', id },
+});
+
+const InterestGroupBadge = ({ id }: { id: string }) => {
+  const { data } = useEntity<Entry>('Entry', id);
+  const name = data?.fields.name?.[LOCALE];
+  return name ? (
+    <Box display="inline">
+      <Badge variant="primary">From {name}</Badge>
+    </Box>
+  ) : null;
+};
+
+type CardProps = {
+  actions: EntryCardProps['actions'];
+  onClick: CustomEntityCardProps['onEdit'];
+  status: EntityStatus;
+};
+
+type AttendanceCardProps = {
+  attended: boolean | null;
+  teamId: string;
+  interestGroupId?: string;
+  inactiveSince?: string;
+} & CardProps;
+
+const AttendanceCard = ({
+  attended,
+  teamId,
+  interestGroupId,
+  inactiveSince,
+  actions,
+  onClick,
+  status,
+}: AttendanceCardProps) => {
+  const { data } = useEntity<Entry>('Entry', teamId);
+  if (!data) {
+    return <EntryCard isLoading />;
+  }
+
+  return (
+    <EntryCard
+      contentType="Attendance"
+      actions={actions}
+      onClick={onClick}
+      status={status}
+    >
+      <Heading marginBottom="none">{data.fields.displayName?.[LOCALE]}</Heading>
+      {attended !== null && (
+        <Text as="p">{attended ? 'Yes' : 'No'}</Text>
+      )}
+      <Stack spacing="spacingXs" marginTop="spacingXs">
+        {interestGroupId && <InterestGroupBadge id={interestGroupId} />}
+        {inactiveSince && (
+          <Box display="inline">
+            <Badge variant="secondary">
+              Inactive since {formatRelativeDateTime(inactiveSince)}
+            </Badge>
+          </Box>
+        )}
+      </Stack>
+    </EntryCard>
+  );
+};
+
+const MissingAttendanceCard = ({ actions, onClick, status }: CardProps) => (
+  <EntryCard
+    contentType="Attendance"
+    actions={actions}
+    onClick={onClick}
+    status={status}
+  >
+    <Text fontColor="colorNegative">No team selected</Text>
+  </EntryCard>
+);
+
+const Card = ({ entity, onEdit, onRemove }: CustomEntityCardProps) => {
+  const sdk = useSDK<FieldExtensionSDK>();
+  const { fields, sys } = entity as Entry;
+  const teamId = fields.team?.[LOCALE]?.sys.id;
+  const interestGroupId = fields.interestGroup?.[LOCALE]?.sys.id;
+  const attended = fields.attended?.[LOCALE];
+  const inactiveSince = fields.inactiveSinceDate?.[LOCALE];
+
+  const removeMembership = async () => {
+    if (sys.publishedVersion) {
+      await sdk.space.unpublishEntry(entity as Entry);
+    }
+    await sdk.space.deleteEntry(entity as Entry);
+    if (onRemove) {
+      onRemove();
+    }
+  };
+
+  const status = entityHelpers.getEntryStatus(sys);
+
+  const defaultProps = {
+    actions: [
+      <MenuItem key="remove" onClick={removeMembership}>
+        Remove
+      </MenuItem>,
+    ],
+    status,
+    onClick: onEdit,
+  };
+
+  return teamId ? (
+    <AttendanceCard
+      {...defaultProps}
+      attended={attended ?? null}
+      teamId={teamId}
+      interestGroupId={interestGroupId}
+      inactiveSince={inactiveSince}
+    />
+  ) : (
+    <MissingAttendanceCard {...defaultProps} />
+  );
+};
+
+export const CustomCard = ({ entity, ...props }: CustomEntityCardProps) => (
+  <Card {...props} entity={entity as Entry} />
+);
+
+const getFieldLinks = (value: unknown): Link[] =>
+  Array.isArray(value) ? (value as Link[]) : [];
+
+const Field = () => {
+  const sdk = useSDK<FieldExtensionSDK>();
+  const cma = useCMA();
+  const [isAddingGroup, setIsAddingGroup] = useState(false);
+  useAutoResizer();
+
+  // Expand an interest group into one attendance entry per member team.
+  // A team already present in the field is skipped so it keeps a single
+  // attendance (the first interest group that contributed it wins).
+  const addInterestGroup = async () => {
+    setIsAddingGroup(true);
+    try {
+      const selected = await sdk.dialogs.selectSingleEntry<Entry>({
+        contentTypes: ['interestGroups'],
+      });
+      if (!selected) {
+        return;
+      }
+      const interestGroupId = selected.sys.id;
+      const interestGroupName = selected.fields?.name?.[LOCALE] as
+        | string
+        | undefined;
+
+      const interestGroup = await cma.entry.get({
+        entryId: interestGroupId,
+      });
+      const joinLinks = getFieldLinks(interestGroup.fields.teams?.[LOCALE]);
+      const joins = await Promise.all(
+        joinLinks.map((link) => cma.entry.get({ entryId: link.sys.id })),
+      );
+      const teamIds = joins
+        .map((join) => join.fields.team?.[LOCALE]?.sys?.id as string | undefined)
+        .filter((id): id is string => Boolean(id));
+
+      const currentLinks = getFieldLinks(sdk.field.getValue());
+      const existingAttendance = await Promise.all(
+        currentLinks.map((link) => cma.entry.get({ entryId: link.sys.id })),
+      );
+      const existingTeamIds = new Set(
+        existingAttendance
+          .map((entry) => entry.fields.team?.[LOCALE]?.sys?.id as string)
+          .filter(Boolean),
+      );
+
+      const uniqueTeamIds = [...new Set(teamIds)];
+      const newTeamIds = uniqueTeamIds.filter((id) => !existingTeamIds.has(id));
+
+      const createdLinks: Link[] = [];
+      for (const teamId of newTeamIds) {
+        // eslint-disable-next-line no-await-in-loop
+        const created = await cma.entry.create(
+          { contentTypeId: 'attendance' },
+          {
+            fields: {
+              team: { [LOCALE]: entryLink(teamId) },
+              attended: { [LOCALE]: false },
+              interestGroup: { [LOCALE]: entryLink(interestGroupId) },
+            },
+          },
+        );
+        // eslint-disable-next-line no-await-in-loop
+        await cma.entry.publish({ entryId: created.sys.id }, created);
+        createdLinks.push(entryLink(created.sys.id));
+      }
+
+      if (createdLinks.length) {
+        await sdk.field.setValue([...currentLinks, ...createdLinks]);
+      }
+
+      const skipped = uniqueTeamIds.length - newTeamIds.length;
+      const label = interestGroupName ?? 'the interest group';
+      sdk.notifier.success(
+        `Added ${newTeamIds.length} team(s) from ${label}.` +
+          (skipped ? ` ${skipped} already in the list.` : ''),
+      );
+    } catch {
+      sdk.notifier.error('Could not add the interest group. Please try again.');
+    } finally {
+      setIsAddingGroup(false);
+    }
+  };
+
+  return (
+    <Stack flexDirection="column" alignItems="stretch" spacing="spacingM">
+      <MultipleEntryReferenceEditor
+        isInitiallyDisabled={false}
+        hasCardEditActions={true}
+        renderCustomCard={CustomCard}
+        parameters={{
+          instance: {
+            showLinkEntityAction: false,
+            showCreateEntityAction: true,
+            bulkEditing: false,
+          },
+        }}
+        viewType="link"
+        sdk={sdk}
+        actionLabels={{
+          createNew: () => 'Add team',
+        }}
+      />
+      <Box>
+        <Button
+          variant="secondary"
+          isLoading={isAddingGroup}
+          isDisabled={isAddingGroup}
+          onClick={() => {
+            void addInterestGroup();
+          }}
+        >
+          Add interest group
+        </Button>
+      </Box>
+    </Stack>
+  );
+};
+
+export default Field;

--- a/packages/contentful-app-extensions/event-attendance/src/locations/Field.tsx
+++ b/packages/contentful-app-extensions/event-attendance/src/locations/Field.tsx
@@ -19,11 +19,7 @@ import {
   formatRelativeDateTime,
 } from '@contentful/f36-components';
 import { FieldExtensionSDK, Entry, Link } from '@contentful/app-sdk';
-import {
-  useSDK,
-  useCMA,
-  useAutoResizer,
-} from '@contentful/react-apps-toolkit';
+import { useSDK, useCMA, useAutoResizer } from '@contentful/react-apps-toolkit';
 
 const LOCALE = 'en-US';
 
@@ -76,9 +72,7 @@ const AttendanceCard = ({
       status={status}
     >
       <Heading marginBottom="none">{data.fields.displayName?.[LOCALE]}</Heading>
-      {attended !== null && (
-        <Text as="p">{attended ? 'Yes' : 'No'}</Text>
-      )}
+      {attended !== null && <Text as="p">{attended ? 'Yes' : 'No'}</Text>}
       <Stack spacing="spacingXs" marginTop="spacingXs">
         {interestGroupId && <InterestGroupBadge id={interestGroupId} />}
         {inactiveSince && (
@@ -185,7 +179,9 @@ const Field = () => {
         joinLinks.map((link) => cma.entry.get({ entryId: link.sys.id })),
       );
       const teamIds = joins
-        .map((join) => join.fields.team?.[LOCALE]?.sys?.id as string | undefined)
+        .map(
+          (join) => join.fields.team?.[LOCALE]?.sys?.id as string | undefined,
+        )
         .filter((id): id is string => Boolean(id));
 
       const currentLinks = getFieldLinks(sdk.field.getValue());

--- a/packages/contentful-app-extensions/event-attendance/src/react-app-env.d.ts
+++ b/packages/contentful-app-extensions/event-attendance/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/packages/contentful-app-extensions/event-attendance/src/test/locations/Field.test.tsx
+++ b/packages/contentful-app-extensions/event-attendance/src/test/locations/Field.test.tsx
@@ -7,11 +7,7 @@ import {
   CustomEntityCardProps,
   useEntity,
 } from '@contentful/field-editor-reference';
-import {
-  useSDK,
-  useCMA,
-  useAutoResizer,
-} from '@contentful/react-apps-toolkit';
+import { useSDK, useCMA, useAutoResizer } from '@contentful/react-apps-toolkit';
 import Field, { CustomCard } from '../../locations/Field';
 
 jest.mock('@contentful/react-apps-toolkit', () => ({
@@ -179,13 +175,19 @@ describe('Field component', () => {
           });
         }
         if (entryId === 'join-1') {
-          return Promise.resolve({ fields: { team: { 'en-US': link('team-1') } } });
+          return Promise.resolve({
+            fields: { team: { 'en-US': link('team-1') } },
+          });
         }
         if (entryId === 'join-2') {
-          return Promise.resolve({ fields: { team: { 'en-US': link('team-2') } } });
+          return Promise.resolve({
+            fields: { team: { 'en-US': link('team-2') } },
+          });
         }
         if (entryId === 'existing-att') {
-          return Promise.resolve({ fields: { team: { 'en-US': link('team-1') } } });
+          return Promise.resolve({
+            fields: { team: { 'en-US': link('team-1') } },
+          });
         }
         return Promise.resolve({ fields: {} });
       });

--- a/packages/contentful-app-extensions/event-attendance/src/test/locations/Field.test.tsx
+++ b/packages/contentful-app-extensions/event-attendance/src/test/locations/Field.test.tsx
@@ -1,0 +1,233 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { FieldExtensionSDK } from '@contentful/app-sdk';
+import {
+  MultipleEntryReferenceEditor,
+  CustomEntityCardProps,
+  useEntity,
+} from '@contentful/field-editor-reference';
+import {
+  useSDK,
+  useCMA,
+  useAutoResizer,
+} from '@contentful/react-apps-toolkit';
+import Field, { CustomCard } from '../../locations/Field';
+
+jest.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: jest.fn(),
+  useCMA: jest.fn(),
+  useAutoResizer: jest.fn(),
+}));
+
+jest.mock('@contentful/field-editor-reference', () => ({
+  MultipleEntryReferenceEditor: jest.fn(),
+  useEntity: jest.fn(),
+}));
+
+jest.mock('@contentful/field-editor-shared', () => ({
+  entityHelpers: {
+    getEntryStatus: jest.fn().mockReturnValue('published'),
+  },
+}));
+
+const link = (id: string) => ({
+  sys: { type: 'Link', linkType: 'Entry', id },
+});
+
+const mockBaseSdk = () => ({
+  space: {
+    unpublishEntry: jest.fn(),
+    deleteEntry: jest.fn(),
+  },
+  field: {
+    getValue: jest.fn().mockReturnValue([]),
+    setValue: jest.fn(),
+  },
+  dialogs: {
+    selectSingleEntry: jest.fn(),
+  },
+  notifier: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+  parameters: { instance: {} },
+});
+
+describe('Field component', () => {
+  let sdk: jest.Mocked<FieldExtensionSDK>;
+  let cma: {
+    entry: {
+      get: jest.Mock;
+      create: jest.Mock;
+      publish: jest.Mock;
+    };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sdk = mockBaseSdk() as unknown as jest.Mocked<FieldExtensionSDK>;
+    cma = {
+      entry: {
+        get: jest.fn(),
+        create: jest.fn(),
+        publish: jest.fn(),
+      },
+    };
+    (useSDK as jest.Mock).mockReturnValue(sdk);
+    (useCMA as jest.Mock).mockReturnValue(cma);
+    (MultipleEntryReferenceEditor as jest.Mock).mockImplementation(() => (
+      <p>MultipleEntryReferenceEditor</p>
+    ));
+  });
+
+  it('enables automatic resizing', () => {
+    render(<Field />);
+    expect(useAutoResizer).toHaveBeenCalled();
+  });
+
+  it('passes a custom card renderer to <MultipleEntryReferenceEditor />', () => {
+    render(<Field />);
+    expect(MultipleEntryReferenceEditor).toHaveBeenCalled();
+    expect(
+      (MultipleEntryReferenceEditor as jest.Mock).mock.lastCall[0]
+        .renderCustomCard,
+    ).toEqual(CustomCard);
+  });
+
+  describe('CustomCard', () => {
+    beforeEach(() => {
+      (useEntity as jest.Mock).mockImplementation((_type, id) => {
+        if (id === 'team-1') {
+          return { data: { fields: { displayName: { 'en-US': 'My Team' } } } };
+        }
+        if (id === 'ig-1') {
+          return { data: { fields: { name: { 'en-US': 'My Group' } } } };
+        }
+        return { data: undefined };
+      });
+    });
+
+    const cardProps = (fields: Record<string, unknown>) =>
+      ({
+        entity: {
+          fields,
+          sys: { type: 'Entry', publishedVersion: 1, version: 1 },
+        },
+        onEdit: jest.fn(),
+        onRemove: jest.fn(),
+      }) as unknown as CustomEntityCardProps;
+
+    it('renders the team name and attended status', async () => {
+      render(
+        <CustomCard
+          {...cardProps({
+            team: { 'en-US': link('team-1') },
+            attended: { 'en-US': true },
+          })}
+        />,
+      );
+      expect(await screen.findByText('My Team')).toBeInTheDocument();
+      expect(screen.getByText('Yes')).toBeInTheDocument();
+    });
+
+    it('renders the interest group origin badge when present', async () => {
+      render(
+        <CustomCard
+          {...cardProps({
+            team: { 'en-US': link('team-1') },
+            attended: { 'en-US': false },
+            interestGroup: { 'en-US': link('ig-1') },
+          })}
+        />,
+      );
+      expect(await screen.findByText('My Team')).toBeInTheDocument();
+      expect(screen.getByText('No')).toBeInTheDocument();
+      expect(screen.getByText('From My Group')).toBeInTheDocument();
+    });
+
+    it('shows an error when no team is selected', async () => {
+      render(<CustomCard {...cardProps({ team: null })} />);
+      expect(await screen.findByText('No team selected')).toBeInTheDocument();
+    });
+
+    it('unpublishes and deletes the entry on remove', async () => {
+      const props = cardProps({ team: null });
+      render(<CustomCard {...props} />);
+      await screen.findByText('No team selected');
+      fireEvent.click(screen.getByLabelText('Actions'));
+      fireEvent.click(screen.getByText('Remove'));
+      await waitFor(() => {
+        expect(sdk.space.unpublishEntry).toHaveBeenCalledWith(props.entity);
+        expect(sdk.space.deleteEntry).toHaveBeenCalledWith(props.entity);
+        expect(props.onRemove).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Add interest group', () => {
+    beforeEach(() => {
+      (useEntity as jest.Mock).mockReturnValue({ data: undefined });
+      sdk.dialogs.selectSingleEntry = jest.fn().mockResolvedValue({
+        sys: { id: 'ig-1' },
+        fields: { name: { 'en-US': 'My Group' } },
+      });
+      cma.entry.get.mockImplementation(({ entryId }) => {
+        if (entryId === 'ig-1') {
+          return Promise.resolve({
+            fields: { teams: { 'en-US': [link('join-1'), link('join-2')] } },
+          });
+        }
+        if (entryId === 'join-1') {
+          return Promise.resolve({ fields: { team: { 'en-US': link('team-1') } } });
+        }
+        if (entryId === 'join-2') {
+          return Promise.resolve({ fields: { team: { 'en-US': link('team-2') } } });
+        }
+        if (entryId === 'existing-att') {
+          return Promise.resolve({ fields: { team: { 'en-US': link('team-1') } } });
+        }
+        return Promise.resolve({ fields: {} });
+      });
+      cma.entry.create.mockImplementation((_ids, data) =>
+        Promise.resolve({ ...data, sys: { id: 'created-1' } }),
+      );
+      cma.entry.publish.mockResolvedValue({});
+    });
+
+    it('creates attendance entries for new teams and skips existing ones', async () => {
+      // team-1 is already in the field via an existing attendance entry.
+      (sdk.field.getValue as jest.Mock).mockReturnValue([link('existing-att')]);
+
+      render(<Field />);
+      fireEvent.click(screen.getByText('Add interest group'));
+
+      await waitFor(() => {
+        expect(cma.entry.create).toHaveBeenCalledTimes(1);
+      });
+      const createdFields = cma.entry.create.mock.calls[0][1].fields;
+      expect(createdFields.team['en-US'].sys.id).toBe('team-2');
+      expect(createdFields.interestGroup['en-US'].sys.id).toBe('ig-1');
+      expect(createdFields.attended['en-US']).toBe(false);
+
+      expect(sdk.field.setValue).toHaveBeenCalledWith([
+        link('existing-att'),
+        link('created-1'),
+      ]);
+      expect(sdk.notifier.success).toHaveBeenCalledWith(
+        'Added 1 team(s) from My Group. 1 already in the list.',
+      );
+    });
+
+    it('does nothing when the dialog is dismissed', async () => {
+      sdk.dialogs.selectSingleEntry = jest.fn().mockResolvedValue(null);
+      render(<Field />);
+      fireEvent.click(screen.getByText('Add interest group'));
+      await waitFor(() => {
+        expect(sdk.dialogs.selectSingleEntry).toHaveBeenCalled();
+      });
+      expect(cma.entry.create).not.toHaveBeenCalled();
+      expect(sdk.field.setValue).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/contentful-app-extensions/event-attendance/tsconfig.json
+++ b/packages/contentful-app-extensions/event-attendance/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "react",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+
+    "target": "es2015",
+    "lib": ["dom", "dom.iterable", "esnext"]
+  },
+  "include": ["src"]
+}

--- a/packages/contentful/migrations/crn/attendance/20260910120000-add-interest-group-to-attendance.js
+++ b/packages/contentful/migrations/crn/attendance/20260910120000-add-interest-group-to-attendance.js
@@ -1,0 +1,30 @@
+module.exports.description = 'Add interest group link to attendance';
+
+module.exports.up = (migration) => {
+  const attendance = migration.editContentType('attendance');
+
+  attendance
+    .createField('interestGroup')
+    .name('Interest Group')
+    .type('Link')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        linkContentType: ['interestGroups'],
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .linkType('Entry');
+
+  attendance.changeFieldControl('interestGroup', 'builtin', 'entryLinkEditor', {
+    showLinkEntityAction: true,
+    showCreateEntityAction: false,
+  });
+};
+
+module.exports.down = (migration) => {
+  const attendance = migration.editContentType('attendance');
+  attendance.deleteField('interestGroup');
+};

--- a/packages/contentful/migrations/crn/events/20260910120100-point-attendance-to-event-attendance-app.js
+++ b/packages/contentful/migrations/crn/events/20260910120100-point-attendance-to-event-attendance-app.js
@@ -1,0 +1,38 @@
+// The event-attendance app is a dedicated field editor forked from the shared
+// membership-reference app. Replace EVENT_ATTENDANCE_APP_ID with the app
+// definition id returned by `contentful-app-scripts upload` for the
+// event-attendance extension before running this migration.
+const EVENT_ATTENDANCE_APP_ID = 'REPLACE_WITH_EVENT_ATTENDANCE_APP_ID';
+const MEMBERSHIP_REFERENCE_APP_ID = 'Yp64pYYDuRNHdvAAAJPYa';
+
+const controlSettings = {
+  entityName: 'team',
+  bulkEditing: false,
+  showUserEmail: false,
+  booleanFieldName: 'attended',
+  showLinkEntityAction: false,
+  showCreateEntityAction: true,
+};
+
+module.exports.description =
+  'Point event attendance field control to the event-attendance app';
+
+module.exports.up = (migration) => {
+  const events = migration.editContentType('events');
+  events.changeFieldControl(
+    'attendance',
+    'app',
+    EVENT_ATTENDANCE_APP_ID,
+    controlSettings,
+  );
+};
+
+module.exports.down = (migration) => {
+  const events = migration.editContentType('events');
+  events.changeFieldControl(
+    'attendance',
+    'app',
+    MEMBERSHIP_REFERENCE_APP_ID,
+    controlSettings,
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -577,6 +577,34 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@asap-hub/contentful-app-event-attendance@workspace:packages/contentful-app-extensions/event-attendance":
+  version: 0.0.0-use.local
+  resolution: "@asap-hub/contentful-app-event-attendance@workspace:packages/contentful-app-extensions/event-attendance"
+  dependencies:
+    "@contentful/app-scripts": "npm:1.33.2"
+    "@contentful/app-sdk": "npm:4.51.0"
+    "@contentful/f36-components": "npm:4.81.1"
+    "@contentful/f36-tokens": "npm:4.2.0"
+    "@contentful/field-editor-reference": "npm:^5.9.0"
+    "@contentful/field-editor-shared": "npm:^1.2.0"
+    "@contentful/react-apps-toolkit": "npm:1.2.23"
+    "@testing-library/dom": "npm:10.4.1"
+    "@testing-library/jest-dom": "npm:^6.9.0"
+    "@testing-library/react": "npm:16.3.2"
+    "@types/jest": "npm:29.5.14"
+    "@types/node": "npm:20.10.5"
+    "@types/react": "npm:18.3.12"
+    "@types/react-dom": "npm:18.3.1"
+    contentful-management: "npm:10.46.4"
+    cross-env: "npm:7.0.3"
+    emotion: "npm:10.0.27"
+    react: "npm:18.3.1"
+    react-dom: "npm:18.3.1"
+    react-scripts: "npm:5.0.1"
+    typescript: "npm:4.9.5"
+  languageName: unknown
+  linkType: soft
+
 "@asap-hub/contentful-app-event-custom-validation@workspace:packages/contentful-app-extensions/event-custom-validation":
   version: 0.0.0-use.local
   resolution: "@asap-hub/contentful-app-event-custom-validation@workspace:packages/contentful-app-extensions/event-custom-validation"


### PR DESCRIPTION
Add a dedicated Contentful field-editor app (event-attendance, forked from membership-reference) that lets editors add interest groups to an event's attendance: each group is expanded into one attendance entry per member team, deduped so a team keeps a single attendance (first group to contribute it wins), with the source group shown as an origin badge.

Persist provenance with an optional interestGroup link on the attendance content type (additive, backward compatible), and point the events attendance field control at the new app.

No application (frontend/backend) changes.